### PR TITLE
Update options.md

### DIFF
--- a/docs/ref-manual/checking/index.md
+++ b/docs/ref-manual/checking/index.md
@@ -1,0 +1,15 @@
+Checking specifications
+=======================
+
+Verification is only as good as the specifications.  Bugs in specifications can
+prevent the Prover from detecting bugs in the contracts.  This chapter describes
+tools that you can use to help find bugs in your specifications.
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+
+sanity.md
+injection.md
+mutation.md
+```

--- a/docs/ref-manual/checking/injection.md
+++ b/docs/ref-manual/checking/injection.md
@@ -1,0 +1,9 @@
+Bug Injection
+=============
+
+One useful way to check specifications is by injecting bugs into the verified
+contracts and checking that the Prover finds the injected bugs.
+
+```{todo}
+This section should be expanded.
+```

--- a/docs/ref-manual/checking/mutation.md
+++ b/docs/ref-manual/checking/mutation.md
@@ -1,0 +1,11 @@
+Mutation Testing
+================
+
+Mutation testing refers to changing the verified code in a way that is likely
+to cause a bug, and then checking that the modified code does not pass
+verification.
+
+```{todo}
+This feature is currently incomplete and undocumented.
+```
+

--- a/docs/ref-manual/checking/sanity.md
+++ b/docs/ref-manual/checking/sanity.md
@@ -1,0 +1,10 @@
+Rule Sanity Checks
+==================
+
+The {ref}`--rule_sanity` option enables some automatic checks that can warn you
+about certain classes of mistakes in specifications.
+
+```{todo}
+This section should be expanded.
+```
+

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -120,7 +120,7 @@ When you have a rule with multiple assertions:
 ### `--rule_sanity`
 
 **What does it do?**
-This mode will do some sanity checks for each rule, based on the attached value, which is allowed to be one of the following: none, basic, advanced.
+This mode will do some sanity checks for each rule, based on the attached value, which is allowed to be one of the following: `none`, `basic`, `advanced`.
 There are 3 kinds of sanity checks:
 1. Reachability- checks that even when ignoring all the user-provided assertions, the end of the rule is reachable. Namely, that the combination of requirements does not create an “empty” rule that is always true.
 

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -131,6 +131,7 @@ When you have a rule with multiple assertions:
 **What does it do?**
 This option enables sanity checking for rules.  The `--rule_sanity` option must
 be followed by one of `none`, `basic`, or `advanced`; these are described below.
+See {doc}`../checking/sanity` for more information about sanity checks.
 
 There are 3 kinds of sanity checks:
 

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -142,8 +142,8 @@ A `require` is considered to be redundant if it can be removed without affecting
 For example, each `require` with expression which is semanticlly equivalant to tautology, will be considered as redundant.
 
 The `rule_sanity` flag accepts one of the following values: `none`, `basic`, `advanced`, to control which sanity checks should be executed.
-The `none` keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.
-The `basic` keyword is intended for running only the reachability check for all the rules and the assert-vacuity check, but only for invariants.
+The `none` keyword behaves the same as not mentioning the `rule_sanity` flag in the configuration at all. No sanity-checks will be executed.
+The `basic` keyword is intended for running only the reachability check for all the rules and the `assert-vacuity` check, but only for invariants.
 Using the `advanced` keyword, all the sanity checks will be executed, for all the invariants/rules.
 It is recommended to start with the `basic` mode, since using the `advanced` mode might results in some false positive alarms.
 

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -129,7 +129,7 @@ When you have a rule with multiple assertions:
 ### `--rule_sanity`
 
 **What does it do?**
-This option enables sanity checking for rules.  The `--rule_sanity` option must
+This option enables sanity checking for rules.  The `--rule_sanity` option may
 be followed by one of `none`, `basic`, or `advanced`; these are described below.
 See {doc}`../checking/sanity` for more information about sanity checks.
 
@@ -195,9 +195,9 @@ There are 3 kinds of sanity checks:
    In this example, the second requirement is redundant, since any `x` greater
    than 3 will also be greater than 2.
 
-The `rule_sanity` flag must be followed by either `none`, `basic`, or `advanced` to control which sanity checks should be executed.
- * With `--rule_sanity none`, no sanity checks are performed; this is the default behavior
- * With `--rule_sanity basic`, the reachability check is performed for all rules and invariants, and the assert-vacuity check is performed for invariants.
+The `rule_sanity` flag may be followed by either `none`, `basic`, or `advanced` to control which sanity checks should be executed.
+ * With `--rule_sanity none` or without passing `--rule_sanity`, no sanity checks are performed.
+ * With `--rule_sanity basic` or just `--rule_sanity`, the reachability check is performed for all rules and invariants, and the assert-vacuity check is performed for invariants.
  * With `--rule_sanity advanced`, all the sanity checks will be performed for all invariants and rules.
 
 We recommend starting with the `basic` mode, since not all rules flagged by the

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -134,7 +134,7 @@ There are 3 kinds of sanity checks:
     _We expect all rules to fail this check._ The exception is the fallback function, which might pass.
 
 2. Assert-Vacuity- checks for each `assert` command in the rule, whether the `assert` is vacuously true.
-An `assert` is considered to be vacuously true if even after all the previous preconditions are removed, the `assert` is always evaluated to true.
+An `assert` is considered to be vacuously true if after all the previous preconditions (`requires` and `if` statements where the `assert` is nested in) are removed, it evaluates to true on every example that reaches it.
 For example, each `assert` with expression which is semanticlly equivalant to tautology, will be considered as vacuosly true.
 
 3. Require-Redundancy- checks for each `require` command in the rule, whether the `require` is redundant.
@@ -145,6 +145,7 @@ The `rule_sanity` flag accepts one of the following values: `none`, `basic`, `ad
 The `none` keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.
 The `basic` keyword is intended for running only the reachability check for all the rules and the assert-vacuity check, but only for invariants.
 Using the `advanced` keyword, all the sanity checks will be executed, for all the invariants/rules.
+It is recommended to start with the `basic` mode, since using the `advanced` mode might results in some false positive alarms.
 
 **When to use it?**  
 We suggest using this option often - before each commit to changes of the source code or verification at the very least. Signs to suspect the rule is “empty“ is when it passes “too easily“ or too quickly.

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -135,11 +135,11 @@ There are 3 kinds of sanity checks:
 
 2. Assert-Vacuity- checks for each `assert` command in the rule, whether the `assert` is vacuously true.
 An `assert` is considered to be vacuously true if after all the previous preconditions (`requires` and `if` statements where the `assert` is nested in) are removed, it evaluates to true on every example that reaches it.
-For example, each `assert` with expression which is semanticlly equivalant to tautology, will be considered as vacuosly true.
+For example, each `assert` with expression which is semantically equivalant to tautology, will be considered as vacuosly true.
 
 3. Require-Redundancy- checks for each `require` command in the rule, whether the `require` is redundant.
 A `require` is considered to be redundant if it can be removed without affecting the satisfiability of the rule.
-For example, each `require` with expression which is semanticlly equivalant to tautology, will be considered as redundant.
+For example, each `require` with expression which is semantically equivalant to tautology, will be considered as redundant.
 
 The `rule_sanity` flag accepts one of the following values: `none`, `basic`, `advanced`, to control which sanity checks should be executed.
 The `none` keyword behaves the same as not mentioning the `rule_sanity` flag in the configuration at all. No sanity-checks will be executed.

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -141,16 +141,16 @@ A `require` is considered to be redundant if it can be removed without affecting
 For example, each `require` with expression which is semanticly equivalant to tautology, will be considered as redundant.
 
 The `rule_sanity` flag accepts one of the following values: `none`, `basic`, `advanced`, to control which sanity checks should be executed.
-The none keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.
-The basic keyword is intended for running only the reachability check for all the rules and the assert-vacuity check, but only for invariants.
-Using the advanced keyword, all the sanity checks will be executed, for all the invariants/rules.
+The `none` keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.
+The `basic` keyword is intended for running only the reachability check for all the rules and the assert-vacuity check, but only for invariants.
+Using the `advanced` keyword, all the sanity checks will be executed, for all the invariants/rules.
 
 **When to use it?**  
 We suggest using this option often - before each commit to changes of the source code or verification at the very least. Signs to suspect the rule is “empty“ is when it passes “too easily“ or too quickly.
 
 **Example**
 
-`certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity`
+`certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity basic`
 
 ### `--short_output`
 

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -119,8 +119,10 @@ When you have a rule with multiple assertions:
 (--rule_sanity)=
 ### `--rule_sanity`
 
-**What does it do?**  
-This mode will check for each rule that even when ignoring all the user-provided assertions, the end of the rule is reachable. Namely, that the combination of requirements does not create an “empty” rule that is always true.
+**What does it do?**
+This mode will do some sanity checks for each rule, based on the attached value, which is allowed to be one of the following: none, basic, advanced.
+There are 3 kinds of sanity checks:
+1. Reachability- checks that even when ignoring all the user-provided assertions, the end of the rule is reachable. Namely, that the combination of requirements does not create an “empty” rule that is always true.
 
 An example of an “empty” rule:  
 `rule empty_rule() {`  
@@ -129,6 +131,15 @@ An example of an “empty” rule:
 `}`
 
 _We expect all rules to fail this check._ The exception is the fallback function, which might pass.
+
+2. Assert-Vacuity- checks for each assert command in the rule, whether the assert is vacuously true, namely, even if all the previous preconditions are removed, the assert is always evaluated to true.
+
+3. Require-Redundancy- checks for each require command in the rule, whether the require is redundant, namely, we could remove it without affecting the satisfiability of the rule.
+
+The rule_sanity flag accepts one of the following values: [none, basic, advanced], to control which sanity checks should be executed.
+The none keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.
+The basic keyword is intended for running only the reachability check for all the rules and the assert-vacuity check, but only for invariants.
+Using the advanced keyword, all the sanity checks will be executed, for all the invariants/rules.
 
 **When to use it?**  
 We suggest using this option often - before each commit to changes of the source code or verification at the very least. Signs to suspect the rule is “empty“ is when it passes “too easily“ or too quickly.

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -132,11 +132,15 @@ An example of an “empty” rule:
 
 _We expect all rules to fail this check._ The exception is the fallback function, which might pass.
 
-2. Assert-Vacuity- checks for each assert command in the rule, whether the assert is vacuously true, namely, even if all the previous preconditions are removed, the assert is always evaluated to true.
+2. Assert-Vacuity- checks for each `assert` command in the rule, whether the `assert` is vacuously true.
+An `assert` is considered to be vacuously true if even after all the previous preconditions are removed, the `assert` is always evaluated to true.
+For example, each `assert` with expression which is semanticly equivalant to tautology, will be considered as vacuosly true.
 
-3. Require-Redundancy- checks for each require command in the rule, whether the require is redundant, namely, we could remove it without affecting the satisfiability of the rule.
+3. Require-Redundancy- checks for each `require` command in the rule, whether the `require` is redundant.
+A `require` is considered to be redundant if it can be removed without affecting the satisfiability of the rule.
+For example, each `require` with expression which is semanticly equivalant to tautology, will be considered as redundant.
 
-The rule_sanity flag accepts one of the following values: [none, basic, advanced], to control which sanity checks should be executed.
+The `rule_sanity` flag accepts one of the following values: `none`, `basic`, `advanced`, to control which sanity checks should be executed.
 The none keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.
 The basic keyword is intended for running only the reachability check for all the rules and the assert-vacuity check, but only for invariants.
 Using the advanced keyword, all the sanity checks will be executed, for all the invariants/rules.

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -124,21 +124,22 @@ This mode will do some sanity checks for each rule, based on the attached value,
 There are 3 kinds of sanity checks:
 1. Reachability- checks that even when ignoring all the user-provided assertions, the end of the rule is reachable. Namely, that the combination of requirements does not create an “empty” rule that is always true.
 
-An example of an “empty” rule:  
-`rule empty_rule() {`  
-`require(x > x)`  
-`assert(y != y)`  
-`}`
+    An example of an “empty” rule:  
+    ```cvl
+    rule empty_rule() {
+      ...
+    }
+    ```
 
-_We expect all rules to fail this check._ The exception is the fallback function, which might pass.
+    _We expect all rules to fail this check._ The exception is the fallback function, which might pass.
 
 2. Assert-Vacuity- checks for each `assert` command in the rule, whether the `assert` is vacuously true.
 An `assert` is considered to be vacuously true if even after all the previous preconditions are removed, the `assert` is always evaluated to true.
-For example, each `assert` with expression which is semanticly equivalant to tautology, will be considered as vacuosly true.
+For example, each `assert` with expression which is semanticlly equivalant to tautology, will be considered as vacuosly true.
 
 3. Require-Redundancy- checks for each `require` command in the rule, whether the `require` is redundant.
 A `require` is considered to be redundant if it can be removed without affecting the satisfiability of the rule.
-For example, each `require` with expression which is semanticly equivalant to tautology, will be considered as redundant.
+For example, each `require` with expression which is semanticlly equivalant to tautology, will be considered as redundant.
 
 The `rule_sanity` flag accepts one of the following values: `none`, `basic`, `advanced`, to control which sanity checks should be executed.
 The `none` keyword behaves the same as not mentioning the rule_sanity flag in the configuration at all. No sanity-checks will be executed.

--- a/docs/ref-manual/cli/options.md
+++ b/docs/ref-manual/cli/options.md
@@ -190,6 +190,7 @@ There are 3 kinds of sanity checks:
      uint x;
      require x > 3;
      require x > 2;
+     assert f(x) == 2, "f must return 2";
    }
    ```
    In this example, the second requirement is redundant, since any `x` greater
@@ -197,7 +198,7 @@ There are 3 kinds of sanity checks:
 
 The `rule_sanity` flag may be followed by either `none`, `basic`, or `advanced` to control which sanity checks should be executed.
  * With `--rule_sanity none` or without passing `--rule_sanity`, no sanity checks are performed.
- * With `--rule_sanity basic` or just `--rule_sanity`, the reachability check is performed for all rules and invariants, and the assert-vacuity check is performed for invariants.
+ * With `--rule_sanity basic` or just `--rule_sanity` without a mode, the reachability check is performed for all rules and invariants, and the assert-vacuity check is performed for invariants.
  * With `--rule_sanity advanced`, all the sanity checks will be performed for all invariants and rules.
 
 We recommend starting with the `basic` mode, since not all rules flagged by the

--- a/docs/ref-manual/index.md
+++ b/docs/ref-manual/index.md
@@ -15,6 +15,7 @@ intro.md
 /docs/user-guide/getting-started/install.md
 cvl/index.md
 approx/index.md
+checking/index.md
 cli/index.md
 portal/using.md
 glossary.md


### PR DESCRIPTION
Update the documentation of the rule_sanity flag.
Two main changes should be done:
1. Documentation for all of the 3 sanity checks we have: Reachability, Assert-Vacuity, Require-Redundancy.
2. Document the new way to use this flag, with the attached values which may be one of the following: `none`,` basic`, `advanced`.