### PR TITLE
added placeholder for user guide on specification designs

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -7,6 +7,7 @@ Certora User's Guide
 intro.md
 getting-started/index.md
 examples.md
+properties/index.md
 patterns/index.md
 ```
 

--- a/docs/user-guide/properties/index.md
+++ b/docs/user-guide/properties/index.md
@@ -1,0 +1,31 @@
+Designing Specifications
+========================
+
+This chapter describes several methods for thinking systematically about
+specifications.
+
+```{todo}
+This section is incomplete.  See
+ * [Thinking about properties tutorial](https://github.com/Certora/Tutorials/tree/master/06.Lesson_ThinkingProperties)
+ * [Video from AAVE workshop](https://youtu.be/QukwpzHhPL0?t=2185) ([slides](https://raw.githubusercontent.com/Certora/Tutorials/AAVE/AAVE/lecture2.pdf))
+```
+
+Method Specifications
+---------------------
+
+Variable Changes
+----------------
+
+Variable Relationships
+----------------------
+
+State-Transition Systems
+------------------------
+
+Risk Assessment
+---------------
+
+Mathematical Properties
+-----------------------
+
+


### PR DESCRIPTION
Added a placeholder section to the user guide with pointers to tutorials on how to think about properties.