### PR TITLE
use correct 'foo.selector' syntax in examples.

### DIFF
--- a/docs/cvl/rules.md
+++ b/docs/cvl/rules.md
@@ -119,8 +119,8 @@ method other than `exampleMethod(uint,uint)` or `otherExample(address)`:
 ```cvl
 rule r(method f, method g) filtered {
     f -> f.isView,
-    g -> g.selector() != exampleMethod(uint,uint).selector
-      && g.selector() != otherExample(address).selector
+    g -> g.selector != exampleMethod(uint,uint).selector
+      && g.selector != otherExample(address).selector
 } {
     // rule body
     ...

--- a/docs/user-guide/patterns/partial-apply.md
+++ b/docs/user-guide/patterns/partial-apply.md
@@ -9,10 +9,10 @@ passed in, and uses method otherwise.
 
 ```cvl
 function applyToUser(method f, env e, address user) {
-    if (f.selector() == balanceOf(address).selector()) {
+    if (f.selector == balanceOf(address).selector) {
         return balanceOf(e, user);
     }
-    if (f.selector() == transfer(address,address).selector()) {
+    if (f.selector == transfer(address,address).selector) {
         address other;
         return transfer(e, user, other);
     }


### PR DESCRIPTION
Prior to this commit, there were 2 instances in the documentation using the old syntax for getting a method's select (e.g. 'foo.selector()'). Now those are using the correct syntax, which does not use the function-like open + closed parentheses.