### PR TITLE
Cloud is supported now

### DIFF
--- a/docs/gambit/index.md
+++ b/docs/gambit/index.md
@@ -1,3 +1,4 @@
+(gambit-intro)=
 Gambit: Mutation Generator for Solidity
 =================================
 

--- a/docs/gambit/mutation-verifier.md
+++ b/docs/gambit/mutation-verifier.md
@@ -26,10 +26,10 @@ java -ea -jar $CERTORA/certora_jars/MutationTest.jar /path/to/config/file/exampl
 - **NOTE: if a path has spaces, put quotes around it to ensure correct parsing by Kotlin's libraries**
 
 ```{note}
-Gambit supports {ref}`--staging`.
+Gambit supports {ref}`--staging` and {ref}`--cloud`.
 
 However, Gambit currently has trouble with
-{ref}`--send_only` and {ref}`--cloud` in the run scripts.
+{ref}`--send_only` in the run scripts.
 If you have these flags, please remove them for now.
 Apologies for the temporary inconvenience!
 ```

--- a/docs/gambit/mutation-verifier.md
+++ b/docs/gambit/mutation-verifier.md
@@ -15,7 +15,8 @@ In the rest of the document,
 
 To use the mutation verifier,
   you will need to {ref}`install the Certora Prover and its dependencies <installation>`.
-  Mutation verification currently requires the `alpha-master` version of the Certora CLI.
+  Mutation verification currently requires
+  the `alpha-master` version of the Certora CLI.
 To install it, run
 
 ```sh

--- a/docs/gambit/mutation-verifier.md
+++ b/docs/gambit/mutation-verifier.md
@@ -18,9 +18,11 @@ Installation instructions can be found [here](https://www.java.com/en/download/h
 
 ## Running the Mutation Verifier
 
-- Example:
+You will need to update your `certora-cli-alpha-master` installation using `pip` to get the relevant
+dependencies. Then you can run Gambit like so:
+
 ```
-java -ea -jar $CERTORA/certora_jars/MutationTest.jar /path/to/config/file/example.conf
+mutationTest path/to/config/file/Example.conf
 ```
 
 - **NOTE: if a path has spaces, put quotes around it to ensure correct parsing by Kotlin's libraries**
@@ -30,7 +32,7 @@ Gambit supports {ref}`--staging` and {ref}`--cloud`.
 
 However, Gambit currently has trouble with
 {ref}`--send_only` in the run scripts.
-If you have these flags, please remove them for now.
+If you have this flag, please remove it for now.
 Apologies for the temporary inconvenience!
 ```
 
@@ -94,6 +96,7 @@ Expects a boolean and defaults to `false`.
 We support `"staging" : true` as an alternative to `"staging" : "master"`.
 Omitting this key will cause verification to run locally
   (unless the run script has it).
+- `"cloud"` : if you instead want to run on the cloud environment you can provide the `--cloud` flag. You can also add the name of a specific branch.
 - `"use_cli_certora_run"` : Use CLI `certoraRun` rather than `certoraRun.py`. Expects a boolean and defaults to `false`.
 
 

--- a/docs/gambit/mutation-verifier.md
+++ b/docs/gambit/mutation-verifier.md
@@ -13,8 +13,23 @@ In the rest of the document,
 
 ## Installations and Setup
 
-You will require java to run the mutation testing jar.
-Installation instructions can be found [here](https://www.java.com/en/download/help/download_options.html).
+To use the mutation verifier,
+  you will need to {ref}`install the Certora Prover and its dependencies <installation>`.
+  Mutation verification currently requires the `alpha-master` version of the Certora CLI.
+To install it, run
+
+```sh
+pip install certora-cli-alpha-master
+```
+
+If you already have `certora-cli-alpha-master` installed and
+  the `mutationTest` command is not available,
+  you may need to update to a newer version by running
+
+```sh
+pip install --upgrade certora-cli-alpha-master
+```
+
 
 ## Running the Mutation Verifier
 
@@ -23,17 +38,6 @@ dependencies. Then you can run Gambit from the command line:
 
 ```
 mutationTest path/to/config/file/Example.conf
-```
-
-- **NOTE: if a path has spaces, put quotes around it to ensure correct parsing by Kotlin's libraries**
-
-```{note}
-Gambit supports {ref}`--staging` and {ref}`--cloud`.
-
-However, Gambit currently has trouble with
-{ref}`--send_only` in the run scripts.
-If you have this flag, please remove it for now.
-Apologies for the temporary inconvenience!
 ```
 
 (gambit-prover-config)=
@@ -82,12 +86,22 @@ manually-written mutants as `.sol` files.
 
 ```{note}
 Any manual mutations files provided must follow the naming
-convention  
+convention
 `OriginalFileName.<unique-name>.sol`, where `<unique-name>` is a string ID unique with respect to the other
 manual mutants (for example you might name them `OriginalFileName.m1.sol`, `OriginalFileName.m2.sol` and so on).
 ```
 
-### Additional Optional Flags for Certora Internal Use
+### Additional Optional Flags
+
+```{note}
+Gambit supports {ref}`--staging` and {ref}`--cloud`.
+
+However, Gambit currently has trouble with
+{ref}`--send_only` in the run scripts.
+If you have this flag, please remove it for now.
+Apologies for the temporary inconvenience!
+```
+
 - `"offline"` : run mutation testing without internet connection, skipping the UI output and other web functions.
 Expects a boolean and defaults to `false`.
 - `"staging"` : if your run script does not already have `--staging`, you can also add it to Gambit.

--- a/docs/gambit/mutation-verifier.md
+++ b/docs/gambit/mutation-verifier.md
@@ -19,7 +19,7 @@ Installation instructions can be found [here](https://www.java.com/en/download/h
 ## Running the Mutation Verifier
 
 You will need to update your `certora-cli-alpha-master` installation using `pip` to get the relevant
-dependencies. Then you can run Gambit like so:
+dependencies. Then you can run Gambit from the command line:
 
 ```
 mutationTest path/to/config/file/Example.conf

--- a/docs/prover/checking/mutation.md
+++ b/docs/prover/checking/mutation.md
@@ -4,8 +4,5 @@ Mutation Testing
 Mutation testing refers to changing the verified code in a way that is likely
 to cause a bug, and then checking that the modified code does not pass
 verification.
-
-```{todo}
-This feature is currently incomplete and undocumented.
-```
+Learn more about how Certora uses mutation testing {ref}`here <gambit-intro>`.
 

--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -1,3 +1,4 @@
+(installation)=
 Installation
 ============
 


### PR DESCRIPTION
This PR updates the gambit documentation to indicate that `--cloud` is now supported.

https://certora-certora-prover-documentation--61.com.readthedocs.build/en/61/docs/gambit/mutation-verifier.html