### PR TITLE
Fixed a semi-vacous rule in the docs

### DIFF
--- a/docs/confluence/map/simple.md
+++ b/docs/confluence/map/simple.md
@@ -135,12 +135,13 @@ We get a call trace that tells us the most important operations performed by the
 ```cvl
 rule insertRevertConditions(uint key, uint value) {
     env e;
+    bool containsKey = contains(key);
     insert@withrevert(e, key, value);
     bool succeeded = !lastReverted;
 
     assert (e.msg.value == 0 
         && value != 0
-        && !contains(key))
+        && !containsKey)
         => succeeded;
 }
 ```


### PR DESCRIPTION
Call to `contains(key)` should be cached before call to insert.
The behaviour is not incorrect since contains only changes if `succeed == true`, and `exp => true` is always true, but would be a good idea to update it for the sake of clarification.