### PR TITLE
Added installation instructions for VS Code Certora IDE extension.

### DIFF
--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -378,7 +378,7 @@ or [navigate there directly](https://marketplace.visualstudio.com/items?itemName
 and follow the prompts to install the extension.
 
 Instructions on how to use the Certora IDE extension are available directly from 
-the extension's marketplace page or from the [extension repository](https://github.com/Certora/vscode-certora-prover).
+the extension's marketplace page.
 
 Congratulations! You have just completed Certora Prover's installation and setup.
 

--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -362,6 +362,24 @@ Step 4: Add the Solidity compiler (`solc`) executable's folder to your `PATH`
     ```
 </details>
 
+Step 5 (for VS Code users): Install the Certora IDE Extension
+--------------------------------------------------------------------------------
+
+All users of the Certora Prover can access the tool using the command line 
+interface, or [CLI](https://docs.certora.com/en/latest/docs/prover/cli/index.html). 
+Those who use Microsoft's Visual Studio Code editor (VS Code) also have the 
+option of using the Certora IDE Extension for that program.
+
+To install VS Code, follow the platform specific instructions found on the 
+[Visual Studio Code website](https://code.visualstudio.com/).
+
+Once VS Code is installed, search for "Certora IDE" in VS Code's extension pane 
+or [navigate there directly](https://marketplace.visualstudio.com/items?itemName=Certora.vscode-certora-prover) 
+and follow the prompts to install the extension.
+
+Instructions on how to use the Certora IDE extension are available directly from 
+the extension's marketplace page or from the [extension repository](https://github.com/Certora/vscode-certora-prover).
+
 Congratulations! You have just completed Certora Prover's installation and setup.
 
 ```{caution}


### PR DESCRIPTION
https://certora-certora-prover-documentation--66.com.readthedocs.build/en/66/docs/user-guide/getting-started/install.html

Added installation instructions for VS Code IDE extension to main prover installation instruction page.