### PR TITLE
Added documentation for generic/builtin rules

### DIFF
--- a/docs/cvl/genericrules.md
+++ b/docs/cvl/genericrules.md
@@ -15,4 +15,4 @@ use builtin rule msgValueInLoopRule
 
 The names of currently implemented rules:
 -----------------------------------------
-msgValueInLoopRule – check for occurrences of msg.value and delegate calls in loops.
+msgValueInLoopRule – check for occurrences of "msg.value" and delegate calls in loops.

--- a/docs/cvl/genericrules.md
+++ b/docs/cvl/genericrules.md
@@ -1,0 +1,18 @@
+Builtin Rules
+=============
+CVT has builtin rules targeted at finding known vulnerabilities. 
+You can add several builtin rules and all other rule types in the same spec file.
+
+
+Sytax
+------
+"use builtin rule" id
+
+
+Example
+-------
+use builtin rule msgValueInLoopRule
+
+The names of currently implemented rules:
+-----------------------------------------
+msgValueInLoopRule – check for occurrences of msg.value and delegate calls in loops.


### PR DESCRIPTION
Currently only one builtin rule for msg.value and delegatecall inside loops.