### PR TITLE
[Proposal] RMP-6 Document the proposal for more expressive summaries

### DIFF
--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -39,7 +39,10 @@ methods          ::= "methods" "{" { method_spec } "}"
 
 method_spec      ::= ( sighash | [ id "." ] id "(" evm_params ")" )
                      [ "returns" types ]
-                     [ "envfree" ]
+                     { | "with" "(" "env" id ")"
+                       | "receiver" "(" "address" id ")"
+                       | "envfree"
+                     }
                      [ "=>" method_summary [ "UNRESOLVED" | "ALL" ] ]
                      [ ";" ]
 
@@ -98,6 +101,11 @@ as separate rules called `envfreeFuncsStaticCheck` and
 [^envfree_nonpayable]: The effect of payable functions on the contract's
   balance depends on the message value, so payable functions also require an
   `env`.
+
+Entries with summaries may also specify variables for the environment of the
+summarized function using `with(env e)`, and the address of the receiver
+contract using `receiver(address a)`.  See
+{ref}`function summaries <function-summary>` below for more details.
 
 Finally, the method entry may contain an optional summarization (indicated by
 `=>` followed by the summary type and an optional application policy).  A
@@ -307,12 +315,77 @@ Contract methods can also be summarized using CVL {doc}`functions` or
 {ref}`ghost-axioms` as approximations.  Contract calls to the summarized method
 are replaced by calls to the specified CVL functions.
 
-To use a CVL function or ghost as a summary, use a call to the function in
-place of the summary type.  The function call can only refer directly to the
-variables defined as arguments in the summary declarations; expressions
-that combine those variables are not supported.
-
 There are a few restrictions on the functions that can be used as approximations:
  - Functions used as summaries are not allowed to call contract functions.
  - Functions used as summaries may not have accept arguments or return values that have struct or array types.
+
+To use a CVL function or ghost as a summary, use a call to the function in
+place of the summary type.  The function call can refer to the
+variables defined as arguments in the summary declarations; expressions
+that combine those variables are not supported.
+
+The call can also refer to variables introduced by the `with(env e)` or
+`receiver(address a)` annotations.  Here `e` or `a` may be replaced with any
+valid identifiers.
+
+The variable defined by the `receiver` clause gives the
+address of the contract on which the summarized method was called (this is
+useful for identifying the called contract in {ref}`wildcard summaries
+<cvl2-wildcards>`).
+
+For example, a wildcard summary for a `transferFrom` method may apply to
+multiple ERC20 contracts; the summary can update the correct ghost variables as
+follows:
+
+```cvl
+methods {
+    function _.transferFrom(address from, address to, uint256 amount) external
+        receiver(address calledContract)
+        => cvlTransferFrom(calledContract, from, to, amount);
+}
+
+ghost mapping(address => mapping(address => mathint)) tokenBalances;
+
+function cvlTransferFrom(address token, address from, address to, uint amount) {
+    if (...) {
+        tokenBalances[token][from] -= amount;
+        tokenBalances[token][to]   += amount;
+    }
+}
+```
+
+The variable defined by the `with` clause contains an {ref}`` `env` type <env>``
+giving the context for the summarized function.  This context may be different
+from the `env` passed to the original call from the spec.  In particular,
+`e.msg.sender` refers to the most recent contract to call an external function
+(as in Solidity).  The variable `e.tx.origin` will be the same as the
+`msg.sender` of the environment for the outermost function call.
+
+Continuing the above example, one can use the `env` to summarize the `transfer`
+method:
+
+```cvl
+methods {
+    function _.transfer(address to, uint256 amount) external
+        with(env e)
+        receiver(address calledContract)
+        => cvlTransfer(calledContract, e, to, amount);
+}
+
+function cvlTransfer(address token, env passedEnv, address to, uint amount) {
+    ...
+}
+
+rule example {
+    env e;
+    address sender;
+    require e.msg.sender == sender;
+    c.process(e);
+}
+```
+
+In this example, if the `process` method calls `t.transfer(...)`, then in the
+`cvlTransfer` function, `token` will be `t` (because of the `receiver` clause
+in the `methods` block entry), `passedEnv.msg.sender` will be
+`c`, and `passedEnv.tx.origin` will be `sender`.
 

--- a/docs/prover/changelog.md
+++ b/docs/prover/changelog.md
@@ -5,7 +5,7 @@ Upcoming features
 -----------------
 
 * Add support for `with(env)` and `callee(address)` for summarization.
-  See {doc}`/docs/cvl/methods`.
+  See {ref}`function-summary`.
 
 Prod version March 21, 2022
 ---------------------------


### PR DESCRIPTION
I'm trying a new process here.  The `expressibility/accepted` branch will contain the official, agreed-upon plan for the new feature described in [RMP-6].  To create or change the plan, we will file PRs against that branch (like this one).  This will give everyone involved an opportunity to review the PR to offer comments and stay informed.

Once the feature has been implemented and released, we will merge `expressibility/accepted` into `master`.

The documentation in this PR differs from the initial idea in [confluence][confluence-proposal] by incorporating @thomasbernardi 's suggestion that we use the same mechanism for introducing variables for the receiver as we do for binding the environment.  It also clarifies how the bound `env` variables are determined.

[confluence-proposal]: https://certora.atlassian.net/wiki/spaces/PROD/pages/480870419/With+env+and+calledContract+summarization