### PR TITLE
[Proposal] remove library keyword; add `storage` modifiers for `external` functions

### DIFF
--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -340,7 +340,7 @@ In CVL 2, methods block entries for internal functions must contain either `call
 as arrays).
 
 Entries for external functions may have `storage` annotations for argument
-references.
+references (in Solidity, external library functions may have storage arguments).
 
 % ```{todo}
 % If you do not change this, you will see the following error:

--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -333,21 +333,14 @@ summarization (if any).
 % in the contract, you will receive the following error message:
 % ```
 
-### `library` annotations
-
-In CVL 2, contract functions declared as library functions must be annotated
-with `library` in the `methods` block.
-
-% ```{todo}
-% If you forget to declare a method as a `library` method, you will receive the
-% following error message:
-% ```
-
 ### Required `calldata`, `memory`, or `storage` annotations for reference types
 
 In CVL 2, methods block entries for internal functions must contain either `calldata`,
 `memory`, or `storage` annotations for all arguments with reference types (such
 as arrays).
+
+Entries for external functions may have `storage` annotations for argument
+references.
 
 % ```{todo}
 % If you do not change this, you will see the following error:

--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -341,6 +341,9 @@ as arrays).
 
 Entries for external functions may have `storage` annotations for argument
 references (in Solidity, external library functions may have storage arguments).
+If a reference-type argument does not have a `storage` annotation, the entry
+will apply to a function that has either a `calldata` or a `memory` annotation
+on the argument.
 
 % ```{todo}
 % If you do not change this, you will see the following error:


### PR DESCRIPTION
Based on the conversation from 5/23 with myself, Naftali, and Thomas, this seems to be the best resolution for the problem of reference types in libraries.

 - external functions may now include `storage` annotations on arguments with reference types
 - the `library` keyword is removed
 - to determine whether a method entry applies, we will generate both library and non-library sighashes; we can do this exactly with the addition of the `storage` modifier.

Generated docs: https://certora-certora-prover-documentation--93.com.readthedocs.build/en/93/docs/cvl/cvl2/changes.html#required-calldata-memory-or-storage-annotations-for-reference-types