### PR TITLE
[DOC-313] Document restrictions on summarization

### DIFF
--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -276,45 +276,10 @@ method by marking the summarization `internal`.
 ```{warning}
 The behavior of `internal` vs. `external` summarization for public methods can
 be confusing, especially because functions called directly from CVL are not
-summarized.
-
-Consider a public function `f`.  Suppose we provide an `internal` summary for
-`f`:
-
- - Calls from CVL to `f` *will* effectively be summarized, because CVL will call
-   the external function, which will then call the internal implementation, and
-   the internal implementation will be summarized.
-
- - Calls from another contract to `f` (or calls to `this.f` from `f`'s contract)
-   *will* effectively be summarized, again because the external function
-   immediately calls the summarized internal implementation.
-
- - Internal calls to `f` will be summarized.
-
-On the other hand, suppose we provide an `external` summary for `f`.  In this
-case:
-
- - Calls from CVL to `f` *will not* be summarized, because direct calls from
-   CVL to contract functions do not use summaries.
-
- - Internal calls to `f` *will not* be summarized - they will use the original
-   implementation.
-
- - External calls to `f` (from Solidity code that calls `this.f` or `c.f`) will
-   be summarized
-
-In most cases, public functions should use an `internal` summary, since this
-effectively summarizes both internal and external calls to the function.
+summarized.  See {ref}`methods-visibility`.
 ```
 
-If the rare case that you want to summarize the internal implementation and the
-external wrapper differently, you can add two separate entries to the `methods`
-block.
-
-% ```{todo}
-% If you do not change this, you will see the following error:
-% ```
-
+(cvl2-optional)=
 ### `optional` methods block entries
 
 In CVL 1, you could write an entry in the methods block for a method that does
@@ -333,6 +298,7 @@ summarization (if any).
 % in the contract, you will receive the following error message:
 % ```
 
+(cvl2-locations)=
 ### Required `calldata`, `memory`, or `storage` annotations for reference types
 
 In CVL 2, methods block entries for internal functions must contain either `calldata`,

--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -322,7 +322,6 @@ The method name can optionally be prefixed by a contract name.  If a contract is
 not explicitly named, the method will be called with `currentContract` as the
 receiver.
 
-
 It is possible for multiple contract methods to match the method call.  This can
 happen in two ways:
  1. The method to be called is a {ref}`method variable <method-type>`
@@ -359,9 +358,12 @@ where `s` is a {ref}`storage variable <storage-type>`.  This indicates that
 before the method is executed, the EVM state should be restored to the saved
 state `s`.
 
-```{todo}
-Unresolved method calls
-```
+### Type restrictions
+
+When calling a contract function, the Prover must convert the arguments and
+return values from their Solidity types to their CVL types and vice-versa.
+There are some restrictions on the types that can be converted.  See
+{ref}`type-conversions` for more details.
 
 (storage-comparison)=
 Comparing storage

--- a/docs/cvl/hooks.md
+++ b/docs/cvl/hooks.md
@@ -94,4 +94,3 @@ slot_pattern ::= slot_pattern_nested:sp {: RESULT = sp; :}
              ;
 
 ```
-

--- a/docs/cvl/hooks.md
+++ b/docs/cvl/hooks.md
@@ -1,3 +1,4 @@
+(hooks)=
 Hooks
 =====
 
@@ -93,3 +94,4 @@ slot_pattern ::= slot_pattern_nested:sp {: RESULT = sp; :}
              ;
 
 ```
+

--- a/docs/cvl/index.md
+++ b/docs/cvl/index.md
@@ -16,7 +16,7 @@ Common Syntactic Elements
 -------------------------
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 3
 
 basics.md
 types.md
@@ -29,7 +29,7 @@ Specification File Contents
 ---------------------------
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 3
 
 pragmas.md
 imports.md

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -1,23 +1,24 @@
 The Methods Block
 =================
 
-The `methods` block contains declarations of contract methods.  Although CVL is
-able to call contract functions even if they are not declared in the methods
-block, the methods block allows users to specify additional information about
-contract methods, and can help document the expected interface of the contract.
+The `methods` block contains additional information about contract methods.
+Although you can call contract functions from CVL even if they are not
+declared in the methods block, the methods block allows users to specify
+additional information about contract methods, and can help document the
+expected interface of the contract.
 
 There are two kinds of declarations:
 
 * **Non-summary declarations** document the interface between the specification
-  and the contracts used during verification.  Non-summary declarations also
-  support spec reuse by allowing specs written against a complete interface to
-  be checked against a contract that only implements part of the interface.
+  and the contracts used during verification (see {ref}`envfree`).  Non-summary
+  declarations also support spec reuse by allowing specs written against a
+  complete interface to be checked against a contract that only implements part
+  of the interface (see {ref}`optional`).
 
-* **Summary declarations** are used to replace calls to methods having the
-  given signature with something that is simpler for the Prover to reason about.
+* **Summary declarations** are used to replace calls to certain contract methods.
   Summaries allow the Prover to reason about external contracts whose code is
   unavailable.  They can also be useful to simplify the code being verified to
-  circumvent timeouts.
+  circumvent timeouts.  See {ref}`summaries`.
 
 ```{caution}
 Summary declarations change the way that some function calls are interpreted,
@@ -32,21 +33,29 @@ functions).
 Syntax
 ------
 
+```{versionchanged} 4.0
+The syntax for methods block entries {doc}`changed in CVL 2 <cvl2/changes>`.
+```
+
 The syntax for the `methods` block is given by the following [EBNF grammar](syntax):
 
 ```
 methods          ::= "methods" "{" { method_spec } "}"
 
-method_spec      ::= ( sighash | [ id "." ] id "(" evm_params ")" )
+method_spec      ::= "function"
+                     ( exact_pattern | wildcard_pattern | catchall_pattern )
                      [ "returns" types ]
                      [ "envfree" ]
                      [ "=>" method_summary [ "UNRESOLVED" | "ALL" ] ]
-                     [ ";" ]
+                     ";"
+
+exact_pattern    ::= [ id "." ] id "(" evm_params ")" visibility [ "returns" "(" evm_types ")" ]
+wildcard_pattern ::= "_" "." id "(" evm_params ")" visibility
+catchall_pattern ::= id "." "_"
+
+visibility ::= "internal" | "external"
 
 evm_param ::= evm_type [ id ]
-
-types ::= cvl_type { "," cvl_type }
-        | "(" [ evm_type [ id ] { "," evm_type [ id ] } ] ")"
 
 method_summary   ::= "ALWAYS" "(" value ")"
                    | "CONSTANT"
@@ -57,36 +66,143 @@ method_summary   ::= "ALWAYS" "(" value ")"
                    | "DISPATCHER" [ "(" ( "true" | "false" ) ")" ]
                    | "AUTO"
                    | id "(" [ id { "," id } ] ")"
-
 ```
 
-See {doc}`types` for the `evm_type` and `cvl_type` productions.  See {doc}`basics`
-for the `id` production.  See {doc}`statements` for the `block` production, and
-{doc}`expr` for the `expression` production.
+See {doc}`types` for the `evm_type` production.  See {doc}`basics`
+for the `id` production.  See {doc}`expr` for the `expression` production.
+
+Methods entry patterns
+----------------------
+
+Each entry in the methods block contains a pattern that matches some set of
+contract functions.
+
+ - {ref}`exact-methods-entries` match a single method of a single contract.
+ - {ref}`wildcard-methods-entries` match a single method signature on all contracts.
+ - {ref}`catchall-methods-entries` match all methods of a single contract.
+
+(exact-methods-entries)=
+### Exact entries
+
+An exact methods block entry matches a single method of a single contract.
+If the contract name is omitted, the default is `currentContract`.
+For example,
+```cvl
+methods {
+    function C.f(uint x) external returns(uint);
+}
+```
+will match the external function `f` of the contract `C`.
+
+Exact methods block entries must include a return type; the Prover will check
+that the declared return type matches the return type of the contract function.
+
+Exact entries may contain {ref}`summaries <summaries>`, {ref}`envfree`, and
+{ref}`optional`.
+
+(wildcard-methods-entries)=
+### Wildcard entries
+
+```{versionadded} 4.0
+Wildcard entries were {ref}`introduced with CVL 2 <cvl2-wildcards>`.
+```
+
+A wildcard entry matches any function in any contract with the indicated name,
+argument types, and visibility.
+For example,
+```cvl
+methods {
+    function _.f(uint x) external => NONDET;
+}
+```
+will match any external function called `f(uint)` in any contract.
+
+Wildcard entries must not declare a return type, since different matched
+methods may return different types.
+
+Wildcard entries may not have {ref}`envfree` or {ref}`optional`; their only
+purpose is {ref}`summarization <summaries>`.  Therefore, wildcard entries must
+have a summary.
+
+(catchall-methods-entries)=
+### Catch-all entries
+
+```{versionadded} 4.0
+% TODO: link to changelog
+```
+
+Catch-all entries match all methods of a given contract.
+
+% TODO: finish
+
+### Location annotations
+
+```{versionadded} 4.0
+Location annotations were {ref}`introduced with CVL 2 <cvl2-locations>`.
+```
+
+Methods block entries for internal functions must contain either `calldata`,
+`memory`, or `storage` annotations for all arguments with reference types (such
+as arrays).
+
+For methods block entries of external functions the location annotation must be
+omitted unless it's the `storage` annotation on an external library function, in
+which case it is required (the reasoning here is to have the information required
+in order to correctly calculate a function's sighash).
+
+(methods-visibility)=
+### Visibility modifiers
+
+```{versionadded} 4.0
+Visibility modifiers were {ref}`introduced with CVL 2 <cvl2-visibility>`.
+```
+
+Entries in the methods block must be marked either `internal` or `external`; the
+entry will only match a function with the indicated visibility.
+
+If a function is declared `public` in Solidity, then the Solidity compiler
+creates an internal implementation method, and an external wrapper method that
+calls the internal implementation.  Therefore, you can summarize a `public`
+method by marking the summarization `internal`.
+
+The behavior of `internal` vs. `external` summarization for public methods can
+be confusing, especially because functions called directly from CVL are not
+summarized.
+
+Consider a public function `f`.  Suppose we provide an `internal` summary for
+`f`:
+
+ - Calls from CVL to `f` *will* effectively be summarized, because CVL will call
+   the external function, which will then call the internal implementation, and
+   the internal implementation will be summarized.
+
+ - Calls from another contract to `f` (or calls to `this.f` from `f`'s contract)
+   *will* effectively be summarized, again because the external function
+   immediately calls the summarized internal implementation.
+
+ - Internal calls to `f` will be summarized.
+
+On the other hand, suppose we provide an `external` summary for `f`.  In this
+case:
+
+ - Calls from CVL to `f` *will not* be summarized, because direct calls from
+   CVL to contract functions do not use summaries.
+
+ - Internal calls to `f` *will not* be summarized - they will use the original
+   implementation.
+
+ - External calls to `f` (from Solidity code that calls `this.f` or `c.f`) will
+   be summarized
+
+In most cases, public functions should use an `internal` summary, since this
+effectively summarizes both internal and external calls to the function.
 
 (envfree)=
-Entries in the `methods` block
-------------------------------
+`envfree` annotations
+---------------------
 
-Each entry in the methods block denotes either the sighash or the type signature
-for a contract method.  Methods of contracts that are introduced by {doc}`using
-statements <using>` can also be described by prefixing the method name with
-the contract variable name.  For example, if contract `C` is introduced by the
-statement `using C as c`, then the method `f(uint)` of contract `c` can be
-referred to as `c.f(uint)`.
-
-It is possible for a method signature to appear in the `methods` block but not
-in the contract being verified.  In this case, the Prover will skip any rules
-that mention the missing method, rather than reporting an error.  This behavior
-allows reusing specifications on contracts that only support part of an
-interface: only the supported methods will be verified.
-
-Following the method signature is an optional `returns` clause.  If a method
-declaration contains a `returns` clause, the declared return type must match
-the contract method's return type.  If the `returns` clause is omitted, the
-return type is taken from the contract method's return type.
-
-Following the `returns` clause is an optional `envfree` tag.  Marking a method
+Following the `returns` clause of an exact methods entry is an optional
+`envfree` tag.  Marking a method
 with `envfree` has two effects.  First, {ref}`calls <call-expr>` to the method
 from CVL do not need to explicitly pass an {term}`environment` value as the
 first argument.  Second, the Prover will verify that the method implementation
@@ -99,62 +215,76 @@ as separate rules called `envfreeFuncsStaticCheck` and
   balance depends on the message value, so payable functions also require an
   `env`.
 
-Finally, the method entry may contain an optional summarization (indicated by
-`=>` followed by the summary type and an optional application policy).  A
-summarized declaration indicates that the Prover should replace some calls to
-the summarized function by an approximation.  This is an important technique
-for working around Prover timeouts and also for working with external contracts
-whose implementation is not fixed at verification time[^internalSummaryCaveat].
+(optional)=
+`optional` annotations
+----------------------
 
-[^internalSummaryCaveat]: Because the internal method calls are not explicit in
-  the compiled bytecode, the Prover needs to use heuristics to determine where
-  internal methods are called in order to summarize them.  Occasionally, these
-  heuristics are unable to locate an internal method call, and therefore they
-  remain unsummarized.  The {ref}`-showInternalFunctions` option can aid in
-  determining whether the Prover was able to identify a specific internal
-  function call or not.
-
-The summary type determines what type of approximation is used to replace the
-function calls.  The available types are described in the following sections:
-
- * {ref}`view-summary`
- * {ref}`havoc-summary`
- * {ref}`dispatcher`
- * {ref}`auto-summary`
- * {ref}`function-summary`
-
-The application policy determines which function calls are replaced by
-approximations.  See {ref}`summaries` for details.
-
-```{todo}
-Some of the method summary types are unsupported for methods having certain
-argument or return types.  The exact limitations are currently undocumented.
+```{versionadded} 4.0
+Prior to {ref}`CVL 2 <cvl2-optional>`, all methods entries used the `optional`
+behavior, and there was no `optional` annotation.
 ```
 
+When multiple contracts implement a shared interface, it is convenient to write
+a generic spec of generic rules.  Some interfaces specify optional methods that
+some implementations provide and others don't.  For example, some ERC20
+implementations contain a `mint` method, but others don't.
+
+In this situation, you might like to write rules that are checked if the
+contract contains the `mint` method and are skipped otherwise.  For example:
+
+```cvl
+methods {
+    function mint(address _to, uint256 _amount, bytes calldata _data) external;
+}
+```
+
+To do so, you can add the `optional` annotation to the exact methods block
+entry for the function.  Any rules that reference an optional method will be
+skipped if the method does not exist in the contract.
+
 (summaries)=
-Which function calls are summarized
------------------------------------
+Summaries
+---------
+
+**Summary declarations** are used to replace calls to methods having the
+given signature with something that is simpler for the Prover to reason about.
+Summaries allow the Prover to reason about external contracts whose code is
+unavailable.  They can also be useful to simplify the code being verified to
+circumvent timeouts.
+
+A summary is indicated by adding `=>` followed by the summary to the end of
+the entry in the methods block.  For example,
+```cvl
+function f(uint) external returns(uint) => ALWAYS(0);
+```
+will replace calls to `f` with an `ALWAYS` summary, while
+```cvl
+function f(uint x) external returns(uint) => cvl_function(x);
+```
+will replace calls to `f` with the CVL function `cvl_function`.
+
+There are several kinds of summaries available:
+
+ - {ref}`view-summary`.  These assume that the called method have no side-effects
+   and simply replace them with a specific value.
+
+ - {ref}`havoc-summary`.  These assume that the called method can have arbitrary
+   side-effects on the storage of some contracts.
+
+ - {ref}`dispatcher`.  A `DISPATCHER` summary assumes that the receiver
+   of the method call is one of a specific set of contracts.
+
+ - {ref}`function-summary` replace calls to the summarized method with {doc}`functions`
+   or {ref}`ghost-axioms`.
+
+ - {ref}`auto-summary` are the default for unresolved calls.
+
+### Summary application
 
 To decide whether to summarize a given internal or external function call, the
 Prover first determines whether it matches any of the declarations in the
 methods block, and then uses the declaration and the calling context to
-determine whether the call should be replaced by an approximation.
-
-To determine whether a call matches a declaration, the tool computes an ABI
-signature for both the call and the method summary.  This ABI signature may be
-simpler than the declaration in Solidity or the `methods` block, because
-ABI signatures are less expressive than Solidity type signatures.  In
-particular, structs are converted into tuples and location annotations such as
-`memory` or `calldata` are dropped.  If there are multiple internal functions or
-multiple method summaries that are converted to the same summarized ABI
-signature, the Prover will report an error.
-
-Method summaries match all calls with the matching ABI signature, including
-internal methods and external methods on all contracts.  There is currently no
-way to apply different summaries to different contracts or to summarize some
-calls and not others to methods with the same ABI signature.  For this reason,
-it is not possible to specify a summary for a method that is qualified by a
-contract name.
+determine whether the call should be replaced by an approximation.[^dont-summarize]
 
 To determine whether a function call is replaced by an approximation, the
 Prover considers the context in which the function is called in addition to the
@@ -177,16 +307,13 @@ to replace a call by an approximation is made as follows:
    function call.  In this case, the verification report will contain a contract
    call resolution warning.
 
-```{todo}
-The `@dontsummarize` tag on method calls is currently undocumented but likely
-affects the summarization behavior.  See {ref}`call-expr`.
-```
+[^dont-summarize]: The `@dontsummarize` tag on method calls affects the
+  summarization behavior.  See {ref}`call-expr`.
 
-Summary types
--------------
+### Summary types
 
 (view-summary)=
-### View summaries: `ALWAYS`, `CONSTANT`, `PER_CALLEE_CONSTANT`, and `NONDET`
+#### View summaries: `ALWAYS`, `CONSTANT`, `PER_CALLEE_CONSTANT`, and `NONDET`
 
 These four summary types treat the summarized methods as view methods: the
 summarized methods are replaced by approximations that do not update the state
@@ -211,8 +338,10 @@ itself).  They differ in the assumptions made about the return value:
    returned values is *not* assumed to match the requested number, unless
    {ref}`-optimisticReturnsize` is specified.
 
+% TODO: restrictions on summaries
+
 (havoc-summary)=
-### Havoc summaries: `HAVOC_ALL` and `HAVOC_ECF`
+#### Havoc summaries: `HAVOC_ALL` and `HAVOC_ECF`
 
 The most conservative summary type is `HAVOC_ALL`.  This summary makes no
 assumptions at all about the called function: it is allowed to have arbitrary
@@ -242,7 +371,7 @@ method to revert.  If you want to ignore this particular revert condition, you
 can pass the {ref}`-optimisticReturnsize` option.
 
 (dispatcher)=
-### `DISPATCHER` summaries
+#### `DISPATCHER` summaries
 
 The `DISPATCHER` summary type provides a useful approximation for methods of
 interfaces that are implemented by multiple contracts.  For example, the
@@ -275,7 +404,7 @@ all cases `DISPATCHER(false)` and `AUTO` report the same set of violations.
 ```
 
 (auto-summary)=
-### `AUTO` summaries
+#### `AUTO` summaries
 
 The behavior of the `AUTO` summary depends on the type of call[^opcodes]:
 
@@ -301,7 +430,7 @@ The behavior of the `AUTO` summary depends on the type of call[^opcodes]:
   in the Solidity manual for details.
 
 (function-summary)=
-### Function summaries
+#### Function summaries
 
 Contract methods can also be summarized using CVL {doc}`functions` or
 {ref}`ghost-axioms` as approximations.  Contract calls to the summarized method
@@ -313,6 +442,21 @@ variables defined as arguments in the summary declarations; expressions
 that combine those variables are not supported.
 
 There are a few restrictions on the functions that can be used as approximations:
+
  - Functions used as summaries are not allowed to call contract functions.
- - Functions used as summaries may not have accept arguments or return values that have struct or array types.
+
+ - The types of any arguments passed to or values returned from the summary
+   must be {ref}`convertible <type-conversions>` between CVL and Solidity types.
+   Arguments that are not accessed in the summary may have any type.
+
+Function summaries for *internal* methods have a few additional restrictions on
+their arguments and return types:
+ - arrays (including static arrays, `bytes`, and `string`) are not supported
+ - struct fields must have [value types][solidity-value-types]
+ - `storage` and `calldata` structs are not supported, only `memory`
+
+You can still summarize functions that take unconvertible types as arguments,
+but you cannot access those arguments in your summary.
+
+[solidity-value-types]: https://docs.soliditylang.org/en/v0.8.11/types.html#value-types
 

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -327,7 +327,11 @@ itself).  They differ in the assumptions made about the return value:
    returned values is *not* assumed to match the requested number, unless
    {ref}`-optimisticReturnsize` is specified.
 
-% TODO: restrictions on summaries
+```{warning}
+Using `CONSTANT` and `PER_CALLEE_CONSTANT` summaries for functions that have
+variable-sized outputs is a potential source of {term}`vacuity` and should be
+avoided.  Prefer a `NONDET` summary where possible.
+```
 
 (havoc-summary)=
 #### Havoc summaries: `HAVOC_ALL` and `HAVOC_ECF`
@@ -358,8 +362,6 @@ methods that return multiple values, the approximations are allowed to return
 the incorrect number of results.  In most cases, this will cause the calling
 method to revert.  If you want to ignore this particular revert condition, you
 can pass the {ref}`-optimisticReturnsize` option.
-
-% TODO: restrictions on havoc summaries
 
 (dispatcher)=
 #### `DISPATCHER` summaries
@@ -393,8 +395,6 @@ of the unknown contract is determined by the optional boolean argument to the
 The most commonly used dispatcher mode is `DISPATCHER(true)`, because in almost
 all cases `DISPATCHER(false)` and `AUTO` report the same set of violations.
 ```
-
-% TODO: restrictions on DISPATCHER summaries
 
 (auto-summary)=
 #### `AUTO` summaries

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -132,10 +132,11 @@ Methods block entries for internal functions must contain either `calldata`,
 `memory`, or `storage` annotations for all arguments with reference types (such
 as arrays).
 
-For methods block entries of external functions the location annotation must be
-omitted unless it's the `storage` annotation on an external library function, in
-which case it is required (the reasoning here is to have the information required
-in order to correctly calculate a function's sighash).
+Entries for external functions may have `storage` annotations for argument
+references (in Solidity, external library functions may have storage arguments).
+If a reference-type argument does not have a `storage` annotation, the entry
+will apply to a function that has either a `calldata` or a `memory` annotation
+on the argument.
 
 (methods-visibility)=
 ### Visibility modifiers
@@ -149,12 +150,12 @@ entry will only match a function with the indicated visibility.
 
 If a function is declared `public` in Solidity, then the Solidity compiler
 creates an internal implementation method, and an external wrapper method that
-calls the internal implementation.  Therefore, you can summarize a `public`
-method by marking the summarization `internal`.
+calls the internal implementation.  An `internal` methods block entry will
+apply to the generated implementation method, while an `external` entry will
+apply to the generated external wrapper method.
 
-The behavior of `internal` vs. `external` summarization for public methods can
-be confusing, especially because functions called directly from CVL are not
-summarized.
+This summarization behavior can be confusing, especially because functions
+called directly from CVL are not summarized.
 
 Consider a public function `f`.  Suppose we provide an `internal` summary for
 `f`:
@@ -394,6 +395,10 @@ of the unknown contract is determined by the optional boolean argument to the
 ```{note}
 The most commonly used dispatcher mode is `DISPATCHER(true)`, because in almost
 all cases `DISPATCHER(false)` and `AUTO` report the same set of violations.
+```
+
+```{note}
+`DISPATCHER` summaries cannot be used to summarize library calls.
 ```
 
 (auto-summary)=

--- a/docs/cvl/overview.md
+++ b/docs/cvl/overview.md
@@ -45,7 +45,7 @@ the following items in any order:
  - **[Ghosts](ghosts):** Ghosts define additional variables that can be used to keep track
    of state changes in the contracts.
 
- - **[Hooks](hooks):** Hooks allow the specification to instrument the contracts being
+ - **{ref}`Hooks <hooks>`:** Hooks allow the specification to instrument the contracts being
    verified to insert additional CVL code when various instructions are executed.
 
 The remainder of this chapter describes the syntax and semantics of a

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -65,6 +65,7 @@ immutables
 injective
 injectivity
 inlined
+inlining
 instantiation
 invariant
 invariants
@@ -100,6 +101,7 @@ reentrancy
 reentrant
 relatedly
 remappings
+representable
 reproducibility
 satisfiability
 satisfiable
@@ -123,11 +125,13 @@ summarization
 summarizations
 supertype
 supertypes
+supercontract
 th
 traceback
 tracebacks
 unary
 unbacked
+unconvertible
 underapproximated
 underapproximates
 underapproximation


### PR DESCRIPTION
This PR documents the restrictions on what functions can be summarized.  Since this is closely related to what types can be passed to and from solidity, I updated that as well.

In addition, since the methods block page was mostly CVL 1, I updated it to CVL 2.

Link to generated documentation:
 - [type conversion](https://certora-certora-prover-documentation--114.com.readthedocs.build/en/114/docs/cvl/types.html#conversions-between-cvl-and-solidity-types)
 - [expression summary restrictions](https://certora-certora-prover-documentation--114.com.readthedocs.build/en/114/docs/cvl/methods.html#function-summaries)
 - [methods block page](https://certora-certora-prover-documentation--114.com.readthedocs.build/en/114/docs/cvl/methods.html#the-methods-block)

