### PR TITLE
[DOC-314] Document the `calledContract` feature

### DIFF
--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -59,7 +59,8 @@ special_vars ::=
            | "_"
            | "max_uint" | "max_address" | "max_uint8" | ... | "max_uint256"
            | "nativeBalances"
-		   
+           | "calledContract"
+
 cast_functions ::=
     | require_functions | to_functions | assert_functions
 
@@ -297,6 +298,9 @@ There are also several built-in variables:
 
   * `nativeBalances` is a mapping of the native token balances, i.e. ETH for Ethereum.
     The balance of an `address a` can be expressed using `nativeBalances[a]`.
+
+ * `calledContract` is only available in {ref}`function summaries <function-summary>`.
+   It refers to the receiver contract of a summarized method call.
 
 
 CVL also has several built-in functions for converting between

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -434,6 +434,9 @@ place of the summary type.  The function call can only refer directly to the
 variables defined as arguments in the summary declarations; expressions
 that combine those variables are not supported.
 
+The function call may also use the special variable `calledContract`, which
+contains the address of the receiver contract of the summarized call.
+
 There are a few restrictions on the functions that can be used as approximations:
 
  - Functions used as summaries are not allowed to call contract functions.


### PR DESCRIPTION
This builds on top of #114, so that should be merged first.

Link to generated documentation: https://certora-certora-prover-documentation--115.com.readthedocs.build/en/115/docs/cvl/methods.html#function-summaries

