### PR TITLE
[CERT-3836] Update install.md

### DIFF
--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -231,6 +231,8 @@ follow the next steps:
     source .zshenv
     ```
 
+When running the Certora Prover in the Visual Studio Code Extension, you need to restart your computer to apply your changes effectively. This will lead otherwise to an error: ```DEBUG: https://prover.certora.com/ "POST /v2/cli/verify HTTP/1.1" 403 447```
+
 </details>
 
 <details>


### PR DESCRIPTION
I was running a basic rule to understand contract logic and recently received my premium key from the team. 

When running a job with the --debug flag, i got this:

DEBUG: https://prover.certora.com/ "POST /v2/cli/verify HTTP/1.1" 403 447

i have set up my key as an environment variable, so i was not sure what else can be the case.

It got finally solved by restarting the computer. I added a change in the documentation for everyone running into the same issue

