### PR TITLE
added reference in types to storage comparison

### DIFF
--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -296,6 +296,10 @@ rule bigger_stake_more_earnings() {
 The `lastStorage` variable contains the state of the EVM after the most recent
 contract function call.
 
+Variables of `storage` type can also be compared for equality, allowing simple
+rules that check the equivalence of different functions.  See
+{ref}`storage-comparison` for details.
+
 (sort)=
 ### Uninterpreted sorts
 


### PR DESCRIPTION
The `storage` section in the types documentation should point to the information on storage comparison; this PR adds that.

https://certora-certora-prover-documentation--151.com.readthedocs.build/en/151/docs/cvl/types.html#the-storage-type