### PR TITLE
[DOC-348] Document `DELETE` summaries

### DIFF
--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -349,10 +349,10 @@ be either `ALL`, `UNRESOLVED`, or `DELETE`; the default policy is `ALL` with the
 of `DISPATCHER` summaries, which have a default of `UNRESOLVED`.
 
 A `DELETE` summary is similar to an `ALL` summary, except that the `DELETE`
-summary removes the method from the {term}`scene` entirely.  The method cannot
-be called from CVL, and {term}`parametric rule`s will not be instantiated on the
-deleted method.  This can drastically improve performance if the deleted method
-is complex.
+summary removes the method from the {term}`scene` entirely.  Calling the method
+from CVL will produce a rule violation, and {term}`parametric rule`s will not
+be instantiated on the deleted method.  This can drastically improve
+performance if the deleted method is complex.
 
 The decision to replace a call by an approximation is made as follows:
 

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -46,7 +46,7 @@ method_spec      ::= "function"
                      ( exact_pattern | wildcard_pattern | catch_all_pattern)
                      [ "returns" "(" evm_types ")" ]
                      [ "envfree" |  "with" "(" "env" id ")" ]
-                     [ "=>" method_summary [ "UNRESOLVED" | "ALL" ] ]
+                     [ "=>" method_summary [ "" | "UNRESOLVED" | "ALL" | "DELETE" ] ]
                      ";"
 
 exact_pattern    ::= [ id "." ] id "(" evm_params ")" visibility [ "returns" "(" evm_types ")" ]
@@ -343,9 +343,16 @@ determine whether the call should be replaced by an approximation.[^dont-summari
 To determine whether a function call is replaced by an approximation, the
 Prover considers the context in which the function is called in addition to the
 application policy for its signature.  If present, the application policy must
-be either `ALL` or `UNRESOLVED`; the default policy is `ALL` with the exception
-of `DISPATCHER` summaries, which have a default of `UNRESOLVED`.  The decision
-to replace a call by an approximation is made as follows:
+be either `ALL`, `UNRESOLVED`, or `DELETE`; the default policy is `ALL` with the exception
+of `DISPATCHER` summaries, which have a default of `UNRESOLVED`.
+
+A `DELETE` summary is similar to an `ALL` summary, except that the `DELETE`
+summary removes the method from the {term}`scene` entirely.  The method cannot
+be called from CVL, and {term}`parametric rule`s will not be instantiated on the
+deleted method.  This can drastically improve performance if the deleted method
+is complex.
+
+The decision to replace a call by an approximation is made as follows:
 
  * If the function is called from CVL rather than from contract code then it is
    never replaced by a summary.

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -333,6 +333,7 @@ There are several kinds of summaries available:
 
  - {ref}`auto-summary` are the default for unresolved calls.
 
+(delete-summary)=
 ### Summary application
 
 To decide whether to summarize a given internal or external function call, the

--- a/docs/cvl/rules.md
+++ b/docs/cvl/rules.md
@@ -95,6 +95,8 @@ always satisfy the rule.
 You can request that the Prover only run with specific methods using the
 {ref}`--method` and {ref}`--contract` command line arguments.  The set of
 methods can also be restricted using {ref}`rule filters <rule-filters>`.
+The Prover will automatically skip any methods that have
+{ref}`` `DELETE` summaries <delete-summary>``.
 
 If you wish to only invoke methods on a certain contract, you can call the
 `method` variable with an explicit receiver contract.  The receiver must be a


### PR DESCRIPTION
Note that this PR builds on #157  and should not be merged before it is.

[Jira ticket](https://certora.atlassian.net/browse/DOC-348)

[Link to generated documentation](https://certora-certora-prover-documentation--158.com.readthedocs.build/en/158/docs/cvl/methods.html#summary-application)

