### PR TITLE
Explain what the length of a dynamic array is

### DIFF
--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -503,7 +503,8 @@ Attempting to access more complex types will yield a type checking error. For ex
 an entire array with `currentContract.myState[0].bar[addr]` will fail.
 
 ```{note}
-Although entire arrays cannot be accessed, the _length_ of the dynamic arrays can be accessed with `.length`, e.g., `currentContract.myState[0].bar[addr].length`.
+Although entire arrays cannot be accessed, the _length_ or the _number of elements_ of the dynamic arrays
+can be accessed with `.length`, e.g., `currentContract.myState[0].bar[addr].length`.
 ```
 
 ```{warning}


### PR DESCRIPTION
This PR just adds a simple clarification about `.length` on dynamic arrays. Given that we also have `.length` for bytes, it is not immediately clear whether an array's length refers to the number of elements in that array, or its length in bytes.

This change reflects my current guess. Please confirm that it actually is correct!