### PR TITLE
better strings

### DIFF
--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -1,4 +1,4 @@
-Release Notes
+Prover Release Notes
 =============
 
 ```{contents}

--- a/docs/prover/changelog/report_changelog.md
+++ b/docs/prover/changelog/report_changelog.md
@@ -1,10 +1,10 @@
-Release Notes
+Verification Report Release Notes
 =============
 ​
 ```{contents}
 ```
 ​
-0.5.6 Report version (October 24, 2023)
+0.5.6 (October 24, 2023)
 ---------------------------
 ​
 ### Features

--- a/docs/prover/changelog/report_changelog.md
+++ b/docs/prover/changelog/report_changelog.md
@@ -1,4 +1,4 @@
-Verification Report Release Notes
+Rules Report Release Notes
 =============
 ​
 ```{contents}


### PR DESCRIPTION
Previously, both the Prover release notes and the verification report release notes appears as release notes, which is ugly and less readable. Also, updated the naming of the report log to have the same convention as the prover log.
