### PR TITLE
DOC-350: Add CERT-926 docs to the v5 changes doc set.

### DIFF
--- a/docs/cvl/v5-changes.md
+++ b/docs/cvl/v5-changes.md
@@ -210,7 +210,7 @@ contract example {
 }
 ```
 
-```cvl
+```{code-block} cvl
 :emphasize-lines: 4
 
 rule for_all() {

--- a/docs/cvl/v5-changes.md
+++ b/docs/cvl/v5-changes.md
@@ -3,7 +3,7 @@ Certora CLI 5.0 Changes
 
 The release of `certora-cli` version 5.0 introduces a few small breaking
 changes for CVL.  These changes improve the coverage for parametric rules and
-invariants, remove support for Solidity function calls in quantified expressions,
+invariants, disallow Solidity function calls in quantified expressions,
 and simplify some rarely-used features.  This document explains those changes
 and how to work with them.
 
@@ -211,6 +211,8 @@ contract example {
 ```
 
 ```cvl
+:emphasize-lines: 4
+
 rule for_all() {
     // Using foo(i) in the quantified body will now cause the prover to
     // generate an error.
@@ -222,7 +224,7 @@ rule for_all() {
 In the example rule `for_all`, the prover will now generate an error similar
 to the following:
 
-```
+```txt
 Error in spec file (test2.spec:8:36): Contract function calls such as foo(i)
 are disallowed inside quantified formulas.
 ```

--- a/docs/cvl/v5-changes.md
+++ b/docs/cvl/v5-changes.md
@@ -224,7 +224,7 @@ rule for_all() {
 In the example rule `for_all`, the prover will now generate an error similar
 to the following:
 
-```txt
+```text
 Error in spec file (test2.spec:8:36): Contract function calls such as foo(i)
 are disallowed inside quantified formulas.
 ```

--- a/docs/cvl/v5-changes.md
+++ b/docs/cvl/v5-changes.md
@@ -198,7 +198,7 @@ Disallow Solidity function calls in quantified expressions
 ----------------------------------------------------------
 
 Starting with `certora-cli` version 5.0, the Prover no longer supports
-making Solidity contract `method` calls in quantified expression bodies by
+making Solidity contract method calls in quantified expression bodies by
 default. For example, given the simple contract below, you can no longer
 use the `method` `foo()` in a quantified expression body.
 
@@ -215,7 +215,7 @@ contract example {
 
 rule for_all() {
     // Using foo(i) in the quantified body will now cause the prover to
-    // generate an error.
+    // generate a type-checking error.
     require (forall uint256 i . i == foo(i));
     assert false, "Prover will generate an error before this line";
 }

--- a/docs/cvl/v5-changes.md
+++ b/docs/cvl/v5-changes.md
@@ -3,8 +3,9 @@ Certora CLI 5.0 Changes
 
 The release of `certora-cli` version 5.0 introduces a few small breaking
 changes for CVL.  These changes improve the coverage for parametric rules and
-invariants, and simplify some rarely-used features.  This document explains
-those changes and how to work with them.
+invariants, remove support for Solidity function calls in quantified expressions,
+and simplify some rarely-used features.  This document explains those changes
+and how to work with them.
 
 ```{note}
 `certora-cli` 5.0 also includes several new features, bug fixes, and
@@ -192,6 +193,50 @@ You can use this option to help transition specs to `certora-cli` 5.0; if `C`
 is the main contract being verified, then passing `--contract C` will cause
 method variables to be instantiated in the same way the would have in older
 versions.
+
+Disallow Solidity function calls in quantified expressions
+----------------------------------------------------------
+
+Starting with `certora-cli` version 5.0, the Prover no longer supports
+making Solidity contract `method` calls in quantified expression bodies by
+default. For example, given the simple contract below, you can no longer
+use the `method` `foo()` in a quantified expression body.
+
+```{code-block} solidity
+contract example {
+   function foo(uint256 i) public pure returns (uint256) {
+       return i;
+   } 
+}
+```
+
+```cvl
+rule for_all() {
+    // Using foo(i) in the quantified body will now cause the prover to
+    // generate an error.
+    require (forall uint256 i . i == foo(i));
+    assert false, "Prover will generate an error before this line";
+}
+```
+
+In the example rule `for_all`, the prover will now generate an error similar
+to the following:
+
+```
+Error in spec file (test2.spec:8:36): Contract function calls such as foo(i)
+are disallowed inside quantified formulas.
+```
+
+Using Solidity `method` calls in the quantified expressions introduced an
+element of instability to quantifier expressions that you can better
+overcome using ghosts, direct storage access, and other access patterns.
+
+
+If you must use Solidity `method` calls in quantified expressions,
+you can still access the old behavior by specifying the
+`--allow_solidity_calls_in_quantifiers` argument to `certoraRun` on the 
+command line.
+
 
 Method variable restrictions
 ----------------------------

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -770,6 +770,7 @@ This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
 
+(--allow_solidity_calls_in_quantifiers)=
 ### --allow_solidity_calls_in_quantifiers
 
 **What does it do?**

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -769,3 +769,19 @@ setting or encoding that models precisely both bitwise operations and `mathint`.
 This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
+
+### --allow_solidity_calls_in_quantifiers
+
+**What does it do?**
+
+Instructs the Prover to permit contract method calls in quantified expression
+bodies.
+
+**When to use it?**
+
+Upon instruction from the Certora team.
+
+**Example**
+
+`--allow_solidity_calls_in_quantifiers` instructs the prover to not generate an
+error on encountering contract method calls in quatified expression bodies.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -784,4 +784,4 @@ Upon instruction from the Certora team.
 **Example**
 
 `--allow_solidity_calls_in_quantifiers` instructs the prover to not generate an
-error on encountering contract method calls in quatified expression bodies.
+error on encountering contract method calls in quantified expression bodies.


### PR DESCRIPTION
### Description

This PR adds text to the v5 breaking changes markdown file in the mike/v5-breaking-changes branch and should be merged with that branch.  The PR contains a description of the changes, an example, a discussion of the motivation for the change, and a way to restore the previous behavior if needed.

Jira ticket: DOC-350
Link to generated documentation: [here](https://certora-certora-prover-documentation--173.com.readthedocs.build/en/173/docs/cvl/v5-changes.html)