### PR TITLE
added link to key signup, removed mentions of the free limited version DOC-165

### DIFF
--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -181,9 +181,9 @@ You can get a personal access key by registering on the
 [Certora website](https://www.certora.com/signup?plan=prover).
 
 Before running the Prover, 
-you should register your access key as a system variable.
-
-To do so on macOS or Linux machines, execute the following command on the terminal:
+  you should register your access key as a system variable.
+To do so on macOS or Linux machines, 
+  execute the following command on the terminal:
 
 ```bash
 export CERTORAKEY=<premium_key>

--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -173,15 +173,15 @@ pip3 install certora-cli-beta
 You can then switch to the standard CVL release by running `deactivate`, and
 back to the beta release using `certora-beta/bin/activate`.
 
-Step 3: Set the premium access key as an environment variable
+Step 3: Set the personal access key as an environment variable
 -------------------------------------------------------------
 
-The Certora Prover requires a personal key. 
-You can get a personal key by registering on the 
+The Certora Prover requires a personal access key. 
+You can get a personal access key by registering on the 
 [Certora website](https://www.certora.com/signup?plan=prover).
 
 Before running the Prover, 
-you should register your key as a system variable.
+you should register your access key as a system variable.
 
 To do so on macOS or Linux machines, execute the following command on the terminal:
 
@@ -190,7 +190,7 @@ export CERTORAKEY=<premium_key>
 ```
 
 This command sets a temporary variable that will be unset once the terminal is
-closed. We recommended storing the key in an environment variable named
+closed. We recommended storing the access key in an environment variable named
 `CERTORAKEY`. This way, you will no longer need to execute the above command
 whenever you open a terminal. To set an environment variable permanently,
 follow the next steps:

--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -176,13 +176,12 @@ back to the beta release using `certora-beta/bin/activate`.
 Step 3: Set the premium access key as an environment variable
 -------------------------------------------------------------
 
-The Certora Prover is available for all to use in a free trial version. The
-Prover's processing power and storage capacity are limited in the trial
-version. If you are using the tool in this way, you can skip to the next step.
+The Certora Prover requires a personal key. 
+You can get a personal key by registering on the 
+[Certora website](https://www.certora.com/signup?plan=prover).
 
-Otherwise, you should have received a personal _premium key_ from the Certora
-team. Before running the Prover in the premium version, you should register the
-premium key as a system variable.
+Before running the Prover, 
+you should register your key as a system variable.
 
 To do so on macOS or Linux machines, execute the following command on the terminal:
 
@@ -191,7 +190,7 @@ export CERTORAKEY=<premium_key>
 ```
 
 This command sets a temporary variable that will be unset once the terminal is
-closed. We recommended storing the premium key in an environment variable named
+closed. We recommended storing the key in an environment variable named
 `CERTORAKEY`. This way, you will no longer need to execute the above command
 whenever you open a terminal. To set an environment variable permanently,
 follow the next steps:

--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -177,7 +177,7 @@ Step 3: Set the personal access key as an environment variable
 -------------------------------------------------------------
 
 The Certora Prover requires a personal access key. 
-You can get a personal access key by registering on the 
+You can get a free personal access key by registering on the 
 [Certora website](https://www.certora.com/signup?plan=prover).
 
 Before running the Prover, 

--- a/docs/user-guide/getting-started/install.md
+++ b/docs/user-guide/getting-started/install.md
@@ -186,7 +186,7 @@ To do so on macOS or Linux machines,
   execute the following command on the terminal:
 
 ```bash
-export CERTORAKEY=<premium_key>
+export CERTORAKEY=<personal_access_key>
 ```
 
 This command sets a temporary variable that will be unset once the terminal is


### PR DESCRIPTION
Before requesting review:
 - Make sure CI is passing
   - Spell check failure may require adding backticks around code or updating `spelling_wordlist.txt`
   - See `README.md` for information about style and markdown syntax
   - If the CI Details link gives a 404, you need to log in to readthedocs.com
 - Add link to generated documentation here
   - you can find this by following the read the docs link from the CI check
 - Ask for help in #documentation

Jira ticket: https://certora.atlassian.net/browse/DOC-165
Link to generated documentation: https://certora-certora-prover-documentation--188.com.readthedocs.build/en/188/docs/user-guide/getting-started/install.html#step-2-install-the-certora-prover-package

