### PR TITLE
Redirecting old google broken link

### DIFF
--- a/docs/user-guide/.htaccess
+++ b/docs/user-guide/.htaccess
@@ -1,0 +1,1 @@
+Redirect /docs/user-guide/getting-started/index.html /docs/user-guide.html

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -1,1 +1,1 @@
-This page moved to https://docs.certora.com/en/latest/docs/user-guide/index.html
+This page [moved](https://docs.certora.com/en/latest/docs/user-guide/index.html)

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -1,1 +1,1 @@
-This page is outdated, please see https://docs.certora.com/en/latest/docs/user-guide/index.html
+This page moved to https://docs.certora.com/en/latest/docs/user-guide/index.html

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -1,1 +1,0 @@
-This page [moved](https://docs.certora.com/en/latest/docs/user-guide/index.html)

--- a/docs/user-guide/getting-started/index.md
+++ b/docs/user-guide/getting-started/index.md
@@ -1,0 +1,1 @@
+This page is outdated, please see https://docs.certora.com/en/latest/docs/user-guide/index.html


### PR DESCRIPTION
This is a quick patch PR to solve a broken link problem.

When googling install Certora prover, links lead to 404 page (https://docs.certora.com/en/latest/docs/user-guide/getting-started/index.html).
The page under the new structure is https://docs.certora.com/en/latest/docs/user-guide/install.html

