### PR TITLE
CERT-6251 - make sure all flags in documentation have a corresponding flag

### DIFF
--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -31,6 +31,7 @@ Modes of operation
 
 The Certora Prover has three modes of operation. The modes are mutually exclusive - you cannot run the tool with more than one mode at a time.
 
+(--verify)=
 ### <a id="verify"></a>`--verify`
 
 **What does it do?**
@@ -45,7 +46,6 @@ If we have a Solidity file `Bank.sol`, with a contract named `Bank` inside it, a
 
 Most frequently used options
 ----------------------------
-
 
 ### <a id="msg"></a>`--msg <description>`
 
@@ -92,6 +92,7 @@ If we want to verify both `withdraw_succeeds` and `withdraw_fails`, we run
 Alternatively, to verify both `withdraw_succeeds` and `withdraw_fails`, we could
 simply run `certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*`
 
+(--exclude_rule)=
 ### <a id="exclude_rule"></a> `--exclude_rule <rule_name_pattern>`
 
 **What does it do?**
@@ -116,6 +117,7 @@ that pass the `--rule` flag(s) and then subtract from them all rules that match
 any `--exclude_rule` flags.
 ```
 
+(--method)=
 ### <a id="method"></a>`--method <method_signature>`
 
 **What does it do?**
@@ -157,6 +159,7 @@ certoraRun --method 'deposit(uint)'
 Note that many shells will interpret the `(` and `)` characters specially, so
 the method signature argument will usually need to be quoted as in the example.
 
+(--parametric_contracts)=
 ### <a id="parametric_contracts"></a>`--parametric_contracts <contract_name> ...`
 
 ```{versionadded} 5.0
@@ -183,6 +186,7 @@ certoraRun Main:Example.sol Underlying:Example.sol --verify Main:Example.spec \
     --parametric_contracts Underlying
 ```
 
+(--wait_for_results)=
 ### <a id="wait_for_results"></a>`--wait_for_results`
 
 **What does it do?**
@@ -205,6 +209,7 @@ certoraRun Example.sol --verify Example:Example.spec --wait_for_results
 
 Options affecting the type of verification run
 ----------------------------------------------
+
 (--multi_assert_check)=
 ### <a id="multi_assert_check"></a>`--multi_assert_check`
 
@@ -240,6 +245,7 @@ When you have a rule with multiple assertions:
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --multi_assert_check`
 
+(--independent_satisfy)=
 ### <a id="independent_satisfy"></a>`--independent_satisfy`
 
 **What does it do?**
@@ -326,6 +332,7 @@ When we do not care much for the output. It is recommended when running the tool
 
 Options that control the Solidity compiler
 ------------------------------------------
+(--solc)=
 ### <a id="solc"></a>`--solc`
 
 **What does it do?**
@@ -337,6 +344,7 @@ Whenever you want to use a Solidity compiler executable with a non-default name.
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1`
 
+(--compiler_map)=
 ### <a id="compiler_map"></a>`--compiler_map`
 
 **What does it do?**
@@ -348,6 +356,7 @@ When different contracts have to be compiled for different Solidity versions.
 **Example**
 `certoraRun Bank.sol Exchange.sol Token.vy --verify Bank:Bank.spec --compiler_map Bank=solc4.25,Exchange=solc6.7,Token=vyper0.3.10`
 
+(--solc_optimize)=
 ### <a id="solc_optimize"></a>`--solc_optimize`
 
 **What does it do?**
@@ -360,6 +369,7 @@ number of times the optimizer will be activated (if no value is set, the compile
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize 300`
 
+(--solc_optimize_map)=
 ### <a id="solc_optimize_map"></a>`--solc_optimize_map`
 
 **What does it do?**
@@ -373,6 +383,7 @@ number of times the optimizer will be activated (if no value is set, the compile
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize_map Bank=200,Exchange=300`
 
+(--solc_via_ir)=
 ### <a id="solc_via_ir"></a>`--solc_via_ir`
 
 **What does it do?**
@@ -419,6 +430,7 @@ By default, we look for the packages in `$NODE_PATH`. If the packages are in any
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --packages_path Solidity/packages`
 
+(--packages)=
 ### <a id="packages"></a>`--packages`
 
 **What does it do?**
@@ -433,6 +445,7 @@ By default we look for the packages in `$NODE_PATH`. If there are packages are i
 Options regarding source code loops
 -----------------------------------
 
+(--optimistic_loop)=
 ### <a id="optimistic_loop"></a>`--optimistic_loop`
 
 **What does it do?**
@@ -447,6 +460,7 @@ When you have loops in your code and are getting a counterexample labeled `loop 
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_loop
 ```
 
+(--loop_iter)=
 ### <a id="loop_iter"></a>`--loop_iter`
 
 **What does it do?**
@@ -464,6 +478,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --loop_iter 2
 Options regarding summarization
 -------------------------------
 
+(--optimistic_summary_recursion)=
 ### <a id="optimistic_summary_recursion"></a>`--optimistic_summary_recursion`
 
 **What does it do?**
@@ -506,6 +521,7 @@ Note that this flag could be another cause for unsoundness - even if such recurs
 _could_ actually happen in the deployed contract, this code-path won't be verified.
 ```
 
+(--summary_recursion_limit)=
 ### <a id="summary_recursion_limit"></a>`--summary_recursion_limit`
 
 **What does it do?**
@@ -534,6 +550,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --summary_recursion_limit 3
 ```
 
 
+(--nondet_difficult_funcs)=
 ### <a id="nondet_difficult_funcs"></a>`--nondet_difficult_funcs`
 
 **What does it do?**
@@ -556,6 +573,7 @@ verification results, as well as highlighting potentially difficult functions.
 certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 ```
 
+(--nondet_minimal_difficulty)=
 ### <a id="nondet_minimal_difficulty"></a>`--nondet_minimal_difficulty`
 
 **What does it do?**
@@ -577,6 +595,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs --nondet_mi
 Options regarding hashing of unbounded data
 -------------------------------------------
 
+(--optimistic_hashing)=
 ### <a id="optimistic_hashing"></a>`--optimistic_hashing`
 
 **What does it do?**
@@ -596,6 +615,7 @@ When the assertion regarding unbounded hashing is thrown, but it is acceptable f
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 ```
 
+(--hashing_length_bound)=
 ### <a id="hashing_length_bound"></a>`--hashing_length_bound`
 
 **What does it do?**
@@ -635,6 +655,7 @@ When you are trying to solve/understand a counterexample of a parametric rule on
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --method 'withdraw(uint256,bool)'`
 
+(--compilation_steps_only)=
 ### <a id="compilation_steps_only"></a>`--compilation_steps_only`
 
 **What does it do?**
@@ -655,6 +676,7 @@ Here are a few example scenarios:
 certoraRun Example.sol --verify Example:Example.spec --compilation_steps_only
 ```
 
+(--smt_timeout)=
 ### <a id="smt_timeout"></a>`--smt_timeout <seconds>`
 
 **What does it do?**
@@ -683,6 +705,7 @@ The second use is when the solvers can prove the property, they just need more t
 `certoraRun Bank.sol --verify Bank:Bank.spec --smt_timeout 300`
 
 
+(--global_timeout)=
 ### <a id="global_timeout"></a>`--global_timeout <seconds>`
 Sets the maximal timeout for the Prover.
 Gets an integer input, which represents seconds.
@@ -712,6 +735,7 @@ Note that even if in the shorter running time not all rules were processed, a se
 Options to set addresses and link contracts
 -------------------------------------------
 
+(--link)=
 ### <a id="link"></a>`--link`
 
 **What does it do?**
@@ -727,6 +751,7 @@ Assume we have the contract `Bank.sol` with the following code snippet:
 We have a contract `BankToken.sol`, and `underlyingToken` should be its address. To do that, we use:
 `certoraRun Bank.sol BankToken.sol --verify Bank:Bank.spec --link Bank:underlyingToken=BankToken`
 
+(--address)=
 ### <a id="address"></a>`--address`
 
 **What does it do?**
@@ -763,6 +788,7 @@ struct TokenPair {
 We have two contracts `BankToken.sol` and `LoanToken.sol`. We want `tokenA` of the `tokenPair` to be `BankToken`, and `tokenB` to be `LoanToken`. Addresses take up only one slot. We assume `tokenPair` is the first field of Bank (so it starts at slot zero). To do that, we use:
 `certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --structLink Bank:0=BankToken Bank:1=LoanToken`
 
+(--contract_recursion_limit)=
 ### <a id="contract_recursion_limit"></a>`--contract_recursion_limit`
 
 **What does it do?**
@@ -802,6 +828,7 @@ as the code may in fact allow theoretically unbounded recursion.
 certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 ```
 
+(--optimistic_contract_recursion)=
 ### <a id="optimistic_contract_recursion"></a>`--optimistic_contract_recursion`
 
 **What does it do?**
@@ -825,6 +852,7 @@ beyond the specified recursion limit ({ref}`--contract_recursion_limit`).
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_contract_recursion true --contract_recursion_limit 1
 ```
 
+(-optimisticFallback)=
 ### <a id="optimistic_fallback"></a>`--optimistic_fallback`
 
 This option determines whether to optimistically assume unresolved external
@@ -836,6 +864,7 @@ calls with an empty input buffer will {term}`havoc` all the storage state of ext
 Options for controlling contract creation
 -----------------------------------------
 
+(--dynamic_bound)=
 ### <a id="dynamic_bound"></a>`--dynamic_bound <n>`
 
 **What does it do?**
@@ -939,6 +968,7 @@ Upon instruction from the Certora team.
 
 `--java_args '"-Dcvt.default.parallelism=2"'` - will set the number of “tasks” that can run in parallel to 2.
 
+(--prover_args)=
 ### <a id="prover_args"></a>`--prover_args`
 
 The `--prover_args` option allows you to provide fine-grained tuning options to the
@@ -946,6 +976,7 @@ Prover.  `--prover_args` receives a string containing Prover-specific options, a
 `--prover_args` cannot set Prover options that are set by standalone `certoraRun` options (e.g. the Prover option `--t` is
 set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_args` value must be quoted
 
+(-optimisticReturnsize)=
 #### <a id="optimisticReturnsize"></a>`--prover_args '-optimisticReturnsize=true'`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
@@ -959,6 +990,7 @@ expected number of return values, then the `RETURNSIZE` value will be set to
 the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
+(-superOptimisticReturnsize)=
 #### <a id="superOptimisticReturnsize"></a>`--prover_args '-superOptimisticReturnsize=true'`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
@@ -966,6 +998,7 @@ that the called method returns the correct number of return values.
 It will set the value returned by the `RETURNSIZE` EVM instruction
 to the size of the output buffer as specified by the summarized `CALL` instruction.
 
+(--precise_bitwise_ops)=
 #### <a id="precise_bitwise_ops"></a>`--precise_bitwise_ops`
 
 This option models bitwise operations exactly instead of using the default
@@ -978,21 +1011,25 @@ precisely: the maximum supported integer value is :math:`2^256-1` in this case,
 effectively restricting a `mathint` to a `uint256`. We currently do not have a
 setting or encoding that models precisely both bitwise operations and `mathint`.
 
+(-smt_groundQuantifiers)=
 #### <a id="smt_groundQuantifiers"></a>`--prover_args -smt_groundQuantifiers=false`
 
 This option disables quantifier grounding.  See {ref}`grounding` for more
 information.
 
+(-maxNumberOfReachChecksBasedOnDomination)=
 #### <a id="maxNumberOfReachChecksBasedOnDomination"></a>`--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'`
 
 This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
+(-enableStorageSplitting)=
 #### <a id="enableStorageSplitting"></a>`--prover_args '-enableStorageSplitting false'`
 
 This option disables the storage splitting optimization.
 
 
+(--allow_solidity_calls_in_quantifiers)=
 ### <a id="allow_solidity_calls_in_quantifiers"></a>`--allow_solidity_calls_in_quantifiers`
 
 **What does it do?**
@@ -1016,6 +1053,7 @@ Control flow splitting options
 
 See [here](control-flow-splitting) for an explanation of control flow splitting.
 
+(-depth)=
 ### <a id="depth"></a>`--prover_args '-depth <number>'`
 
 **What does it do?**
@@ -1039,6 +1077,7 @@ The default value for this option is 10.
 certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-depth 5'
 ```
 
+(-mediumTimeout)=
 ### <a id="mediumTimeout"></a>`--prover_args '-mediumTimeout <seconds>'`
 
 The "medium timeout" determines how much time the SMT solver gets for checking a
@@ -1064,6 +1103,7 @@ a given depth.
 certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-mediumTimeout 20'
 ```
 
+(-dontStopAtFirstSplitTimeout)=
 ### <a id="dontStopAtFirstSplitTimeout"></a>`--prover_args '-dontStopAtFirstSplitTimeout <true/false>'`
 
 **What does it do?**
@@ -1087,6 +1127,7 @@ The default value for this option is `false`.
 certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-dontStopAtFirstSplitTimeout true'
 ```
 
+(-smt_initialSplitDepth)=
 ### <a id="smt_initialSplitDepth"></a>`--prover_args '-smt_initialSplitDepth <number>'`
 
 With this option, the splitting can be configured to skip the SMT solver-based checks

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -205,7 +205,7 @@ certoraRun Example.sol --verify Example:Example.spec --wait_for_results
 
 Options affecting the type of verification run
 ----------------------------------------------
-
+(--multi_assert_check)=
 ### <a id="multi_assert_check"></a>`--multi_assert_check`
 
 **What does it do?**
@@ -298,6 +298,7 @@ When you have a rule with multiple satisfy statements, and you would like to dem
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --independent_satisfy`
 
+(--rule_sanity)=
 ### <a id="rule_sanity"></a>`--rule_sanity`
 
 **What does it do?**

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -345,6 +345,7 @@ Whenever you want to use a Solidity compiler executable with a non-default name.
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1`
 
 (--compiler_map)=
+(--solc_map)=
 ### <a id="compiler_map"></a>`--compiler_map`
 
 **What does it do?**

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -31,8 +31,7 @@ Modes of operation
 
 The Certora Prover has three modes of operation. The modes are mutually exclusive - you cannot run the tool with more than one mode at a time.
 
-(--verify)=
-### `--verify`
+### <a id="verify"></a>`--verify`
 
 **What does it do?**
 It runs formal verification of properties specified in a .spec file on a given contract. Each contract must have been declared in the input files or have the same name as the source code file it is in.
@@ -47,7 +46,8 @@ If we have a Solidity file `Bank.sol`, with a contract named `Bank` inside it, a
 Most frequently used options
 ----------------------------
 
-### `--msg <description>`
+
+### <a id="msg"></a>`--msg <description>`
 
 **What does it do?**
 Adds a message description to your run, similar to a commit message. This message will appear in the title of the completion email sent to you. Note that you need to wrap your message in quotes if it contains spaces.
@@ -60,7 +60,7 @@ To create the message above, we used
 `certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'`
 
 (--rule)=
-### `--rule <rule_name_pattern> ...`
+### <a id="rule"></a>`--rule <rule_name_pattern> ...`
 
 **What does it do?**
 Formally verifies one or more given properties instead of the whole specification file. An invariant can also be selected.
@@ -92,8 +92,7 @@ If we want to verify both `withdraw_succeeds` and `withdraw_fails`, we run
 Alternatively, to verify both `withdraw_succeeds` and `withdraw_fails`, we could
 simply run `certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*`
 
-(--exclude_rule)=
-### `--exclude_rule <rule_name_pattern>`
+### <a id="exclude_rule"></a> `--exclude_rule <rule_name_pattern>`
 
 **What does it do?**
 It is the opposite flag to {ref}`--rule` - use it to specify a list of rules that
@@ -117,8 +116,7 @@ that pass the `--rule` flag(s) and then subtract from them all rules that match
 any `--exclude_rule` flags.
 ```
 
-(--method)=
-### `--method <method_signature>`
+### <a id="method"></a>`--method <method_signature>`
 
 **What does it do?**
 Only uses functions with the given method signature when instantiating
@@ -159,8 +157,7 @@ certoraRun --method 'deposit(uint)'
 Note that many shells will interpret the `(` and `)` characters specially, so
 the method signature argument will usually need to be quoted as in the example.
 
-(--parametric_contracts)=
-### `--parametric_contracts <contract_name> ...`
+### <a id="parametric_contracts"></a>`--parametric_contracts <contract_name> ...`
 
 ```{versionadded} 5.0
 Prior to version 5, method variables and invariants were only instantiated with
@@ -186,8 +183,7 @@ certoraRun Main:Example.sol Underlying:Example.sol --verify Main:Example.spec \
     --parametric_contracts Underlying
 ```
 
-(--wait_for_results)=
-### `--wait_for_results`
+### <a id="wait_for_results"></a>`--wait_for_results`
 
 **What does it do?**
 Wait for verification results after sending the verification request.
@@ -210,8 +206,7 @@ certoraRun Example.sol --verify Example:Example.spec --wait_for_results
 Options affecting the type of verification run
 ----------------------------------------------
 
-(--multi_assert_check)=
-### `--multi_assert_check`
+### <a id="multi_assert_check"></a>`--multi_assert_check`
 
 **What does it do?**
 This mode checks each assertion statement that occurs in a rule, separately. The check is done by decomposing each rule into multiple sub-rules, each of which checks one assertion, while it assumes all preceding assertions. In addition, all assertions that originate from the Solidity code (as opposed to those from the specification), are checked together by a designated, single sub-rule.
@@ -245,8 +240,7 @@ When you have a rule with multiple assertions:
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --multi_assert_check`
 
-(--independent_satisfy)=
-### `--independent_satisfy`
+### <a id="independent_satisfy"></a>`--independent_satisfy`
 
 **What does it do?**
 The independent satisfy mode checks each {ref}`satisfy statement <satisfy>` independently from all other satisfy statements that occurs in a rule.
@@ -304,8 +298,7 @@ When you have a rule with multiple satisfy statements, and you would like to dem
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --independent_satisfy`
 
-(--rule_sanity)=
-### `--rule_sanity`
+### <a id="rule_sanity"></a>`--rule_sanity`
 
 **What does it do?**
 This option enables sanity checking for rules.  The `--rule_sanity` option may
@@ -319,7 +312,7 @@ useful check if you notice rules passing surprisingly quickly or easily.
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity basic`
 
-### `--short_output`
+### <a id="short_output"></a>`--short_output`
 
 **What does it do?**
 Reduces the verbosity of the tool.
@@ -332,8 +325,7 @@ When we do not care much for the output. It is recommended when running the tool
 
 Options that control the Solidity compiler
 ------------------------------------------
-(--solc)=
-### `--solc`
+### <a id="solc"></a>`--solc`
 
 **What does it do?**
 Use this option to provide a path to the Solidity compiler executable file. We check in all directories in the `$PATH` environment variable for an executable with this name. If `--solc` is not used, we look for an executable called `solc`, or `solc.exe` on windows platforms.
@@ -344,8 +336,7 @@ Whenever you want to use a Solidity compiler executable with a non-default name.
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1`
 
-(--solc_map)=
-### `--compiler_map`
+### <a id="compiler_map"></a>`--compiler_map`
 
 **What does it do?**
 Compiles every smart contract with a different compiler executable (Solidity version or Vyper). All used contracts must be listed.
@@ -356,8 +347,7 @@ When different contracts have to be compiled for different Solidity versions.
 **Example**
 `certoraRun Bank.sol Exchange.sol Token.vy --verify Bank:Bank.spec --compiler_map Bank=solc4.25,Exchange=solc6.7,Token=vyper0.3.10`
 
-(--solc_optimize)=
-### `--solc_optimize`
+### <a id="solc_optimize"></a>`--solc_optimize`
 
 **What does it do?**
 Passes the value of this option as is to the solidity compiler's option `--optimize` and `--optimize-runs`.
@@ -369,8 +359,7 @@ number of times the optimizer will be activated (if no value is set, the compile
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize 300`
 
-(--solc_optimize_map)=
-### `--solc_optimize_map`
+### <a id="solc_optimize_map"></a>`--solc_optimize_map`
 
 **What does it do?**
 Set optimize values when different files run with different number of runs
@@ -383,8 +372,7 @@ number of times the optimizer will be activated (if no value is set, the compile
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize_map Bank=200,Exchange=300`
 
-(--solc_via_ir)=
-### `--solc_via_ir`
+### <a id="solc_via_ir"></a>`--solc_via_ir`
 
 **What does it do?**
 Passes the value of this option  to the solidity compiler's option `--via-ir`.
@@ -395,7 +383,7 @@ When we want to enable the IR-based code generator
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_via_ir`
 
-### `--solc_evm_version`
+### <a id="solc_evm_version"></a>`--solc_evm_version`
 
 **What does it do?**
 Passes the value of this option  to the solidity compiler's option `--evm-version`.
@@ -406,7 +394,7 @@ When we want to select the Solidity compiler EVM version
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version Istanbul`
 
-### `--solc_allow_path`
+### <a id="solc_allow_path"></a>`--solc_allow_path`
 
 **What does it do?**
 Passes the value of this option as is to the solidity compiler's option `--allow-paths`.
@@ -419,7 +407,7 @@ When we want to add an additional location the Solidity compiler to load sources
 `certoraRun Bank.sol --verify Bank:Bank.spec --solc_allow_path ~/Projects/Bank`
 
 
-### `--packages_path`
+### <a id="packages_path"></a>`--packages_path`
 
 **What does it do?**
 Gets the path to a directory including the Solidity packages.
@@ -430,8 +418,7 @@ By default, we look for the packages in `$NODE_PATH`. If the packages are in any
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --packages_path Solidity/packages`
 
-(--packages)=
-### `--packages`
+### <a id="packages"></a>`--packages`
 
 **What does it do?**
 For each package, gets the path to a directory including that Solidity package.
@@ -445,8 +432,7 @@ By default we look for the packages in `$NODE_PATH`. If there are packages are i
 Options regarding source code loops
 -----------------------------------
 
-(--optimistic_loop)=
-### `--optimistic_loop`
+### <a id="optimistic_loop"></a>`--optimistic_loop`
 
 **What does it do?**
 The Certora Prover unrolls loops - if the loop should be executed three times, it will copy the code inside the loop three times. After we finish the loop's iterations, we add an assertion to verify we have actually finished running the loop. For example, in a `while (a < b)` loop, after the loop's unrolling, we add `assert a >= b`. We call this assertion the _loop unwind condition_.
@@ -460,8 +446,7 @@ When you have loops in your code and are getting a counterexample labeled `loop 
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_loop
 ```
 
-(--loop_iter)=
-### `--loop_iter`
+### <a id="loop_iter"></a>`--loop_iter`
 
 **What does it do?**
 Sets the maximal number of loop iterations we verify for. The way the Certora Prover handles loops is by unrolling them - if the loop should be executed three times, it will copy the code inside the loop three times. This option sets the number of unrolls. Be aware that the run time grows exponentially by the number of loop iterations.
@@ -478,8 +463,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --loop_iter 2
 Options regarding summarization
 -------------------------------
 
-(--optimistic_summary_recursion)=
-### `--optimistic_summary_recursion`
+### <a id="optimistic_summary_recursion"></a>`--optimistic_summary_recursion`
 
 **What does it do?**
 In case there's a call to some Solidity function within a summary, we may end up
@@ -521,8 +505,7 @@ Note that this flag could be another cause for unsoundness - even if such recurs
 _could_ actually happen in the deployed contract, this code-path won't be verified.
 ```
 
-(--summary_recursion_limit)=
-### `--summary_recursion_limit`
+### <a id="summary_recursion_limit"></a>`--summary_recursion_limit`
 
 **What does it do?**
 Summaries can cause recursion (see {ref}`--optimistic_summary_recursion`). This
@@ -550,8 +533,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --summary_recursion_limit 3
 ```
 
 
-(--nondet_difficult_funcs)=
-### `--nondet_difficult_funcs`
+### <a id="nondet_difficult_funcs"></a>`--nondet_difficult_funcs`
 
 **What does it do?**
 When this option is set, the Prover will auto-summarize
@@ -573,8 +555,7 @@ verification results, as well as highlighting potentially difficult functions.
 certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 ```
 
-(--nondet_minimal_difficulty)=
-### `--nondet_minimal_difficulty`
+### <a id="nondet_minimal_difficulty"></a>`--nondet_minimal_difficulty`
 
 **What does it do?**
 This option sets the minimal difficulty threshold for the auto-summarization mode enabled by {ref}`--nondet_difficult_funcs`.
@@ -595,8 +576,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs --nondet_mi
 Options regarding hashing of unbounded data
 -------------------------------------------
 
-(--optimistic_hashing)=
-### `--optimistic_hashing`
+### <a id="optimistic_hashing"></a>`--optimistic_hashing`
 
 **What does it do?**
 
@@ -615,8 +595,7 @@ When the assertion regarding unbounded hashing is thrown, but it is acceptable f
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 ```
 
-(--hashing_length_bound)=
-### `--hashing_length_bound`
+### <a id="hashing_length_bound"></a>`--hashing_length_bound`
 
 **What does it do?**
 
@@ -655,8 +634,7 @@ When you are trying to solve/understand a counterexample of a parametric rule on
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --method 'withdraw(uint256,bool)'`
 
-(--compilation_steps_only)=
-### `--compilation_steps_only`
+### <a id="compilation_steps_only"></a>`--compilation_steps_only`
 
 **What does it do?**
 Exits the program after source code and spec compilation without sending
@@ -676,8 +654,7 @@ Here are a few example scenarios:
 certoraRun Example.sol --verify Example:Example.spec --compilation_steps_only
 ```
 
-(--smt_timeout)=
-### `--smt_timeout <seconds>`
+### <a id="smt_timeout"></a>`--smt_timeout <seconds>`
 
 **What does it do?**
 Sets the maximal timeout for all the
@@ -705,8 +682,7 @@ The second use is when the solvers can prove the property, they just need more t
 `certoraRun Bank.sol --verify Bank:Bank.spec --smt_timeout 300`
 
 
-(--global_timeout)=
-### `--global_timeout <seconds>`
+### <a id="global_timeout"></a>`--global_timeout <seconds>`
 Sets the maximal timeout for the Prover.
 Gets an integer input, which represents seconds.
 
@@ -735,8 +711,7 @@ Note that even if in the shorter running time not all rules were processed, a se
 Options to set addresses and link contracts
 -------------------------------------------
 
-(--link)=
-### `--link`
+### <a id="link"></a>`--link`
 
 **What does it do?**
 Links a slot in a contract with another contract.
@@ -751,8 +726,7 @@ Assume we have the contract `Bank.sol` with the following code snippet:
 We have a contract `BankToken.sol`, and `underlyingToken` should be its address. To do that, we use:
 `certoraRun Bank.sol BankToken.sol --verify Bank:Bank.spec --link Bank:underlyingToken=BankToken`
 
-(--address)=
-### `--address`
+### <a id="address"></a>`--address`
 
 **What does it do?**
 Sets the address of a contract to a given address.
@@ -765,7 +739,7 @@ When we have an external contract with a constant address. By default, the Pytho
 If we wish the `Oracle` contract to be at address 12, we use
 `certoraRun Bank.sol Oracle.sol --verify Bank:Bank.spec --address Oracle:12`
 
-### `--struct_link`
+### <a id="struct_link"></a>`--struct_link`
 
 **What does it do?**
 Links a slot in a struct with another contract. To do that you must calculate the slot number of the field you wish to replace.
@@ -788,8 +762,7 @@ struct TokenPair {
 We have two contracts `BankToken.sol` and `LoanToken.sol`. We want `tokenA` of the `tokenPair` to be `BankToken`, and `tokenB` to be `LoanToken`. Addresses take up only one slot. We assume `tokenPair` is the first field of Bank (so it starts at slot zero). To do that, we use:
 `certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --structLink Bank:0=BankToken Bank:1=LoanToken`
 
-(--contract_recursion_limit)=
-### `--contract_recursion_limit`
+### <a id="contract_recursion_limit"></a>`--contract_recursion_limit`
 
 **What does it do?**
 Contract inlining can cause recursion (see {ref}`--optimistic_contract_recursion`). This
@@ -828,8 +801,7 @@ as the code may in fact allow theoretically unbounded recursion.
 certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 ```
 
-(--optimistic_contract_recursion)=
-### `--optimistic_contract_recursion`
+### <a id="optimistic_contract_recursion"></a>`--optimistic_contract_recursion`
 
 **What does it do?**
 Contract linking can cause recursion (see also {ref}`--contract_recursion_limit`).
@@ -852,8 +824,7 @@ beyond the specified recursion limit ({ref}`--contract_recursion_limit`).
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_contract_recursion true --contract_recursion_limit 1
 ```
 
-(-optimisticFallback)=
-### `--optimistic_fallback`
+### <a id="optimistic_fallback"></a>`--optimistic_fallback`
 
 This option determines whether to optimistically assume unresolved external
 calls with an empty input buffer (length 0) *cannot* make arbitrary changes to all states. It makes changes to how
@@ -864,8 +835,7 @@ calls with an empty input buffer will {term}`havoc` all the storage state of ext
 Options for controlling contract creation
 -----------------------------------------
 
-(--dynamic_bound)=
-### `--dynamic_bound <n>`
+### <a id="dynamic_bound"></a>`--dynamic_bound <n>`
 
 **What does it do?**
 If set to zero (the default), contract creation (via the `new` statement or the `create`/`create2` instructions) will result in a havoc, like any other unresolved external call. If non-zero, then dynamic contract creation will be modeled with cloning, where each contract will be cloned at most n times.
@@ -877,7 +847,7 @@ When you wish to model contract creation, that is, simulating the actual creatio
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site.
 `certoraRun C.sol Foo.sol --dynamic_bound 1`
 
-### `--dynamic_dispatch`
+### <a id="dynamic_dispatch"></a>`--dynamic_dispatch`
 
 **What does it do?**
 If false (the default), then all contract method invocations on newly created instances will be unresolved. The user must explicitly write {ref}`` `DISPATCHER` <dispatcher>`` summaries for all methods called on newly created instances.
@@ -903,7 +873,7 @@ and `Foo` calls some method `m()` which you wish to automatically link to the ne
 Note that you must add a `--dynamic_bound` argument as well.
 `certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch true`
 
-### `--prototype <hex string>=<contract>`
+### <a id="prototype"></a>`--prototype <hex string>=<contract>`
 
 **What does it do?**
 Instructs the Prover to use a specific contract type for the return value from a call to `create` or `create2` on the given hexadecimal string as a prefix. The hexadecimal string represents proxy code that forwards calls to another contract. As we are using the prototype flag to skip calls to the proxy, no constructor code is being simulated for these contract creation resolutions.
@@ -937,7 +907,7 @@ Version options
 -----------------
 
 
-### `--version`
+### <a id="version"></a>`--version`
 
 **What does it do?**
 Shows the version of the local installation of the tool you have.
@@ -954,7 +924,7 @@ Advanced options
 ----------------
 
 
-### `--java_args`
+### <a id="java_args"></a>`--java_args`
 
 **What does it do?**
 
@@ -968,16 +938,14 @@ Upon instruction from the Certora team.
 
 `--java_args '"-Dcvt.default.parallelism=2"'` - will set the number of “tasks” that can run in parallel to 2.
 
-(--prover_args)=
-### `--prover_args`
+### <a id="prover_args"></a>`--prover_args`
 
 The `--prover_args` option allows you to provide fine-grained tuning options to the
 Prover.  `--prover_args` receives a string containing Prover-specific options, and will be sent as-is to the Prover.
 `--prover_args` cannot set Prover options that are set by standalone `certoraRun` options (e.g. the Prover option `--t` is
 set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_args` value must be quoted
 
-(-optimisticReturnsize)=
-#### `--prover_args '-optimisticReturnsize=true'`
+#### <a id="optimisticReturnsize"></a>`--prover_args '-optimisticReturnsize=true'`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
@@ -990,16 +958,14 @@ expected number of return values, then the `RETURNSIZE` value will be set to
 the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
-(-superOptimisticReturnsize)=
-#### `--prover_args '-superOptimisticReturnsize=true'`
+#### <a id="superOptimisticReturnsize"></a>`--prover_args '-superOptimisticReturnsize=true'`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
 It will set the value returned by the `RETURNSIZE` EVM instruction
 to the size of the output buffer as specified by the summarized `CALL` instruction.
 
-(--precise_bitwise_ops)=
-#### `--precise_bitwise_ops`
+#### <a id="precise_bitwise_ops"></a>`--precise_bitwise_ops`
 
 This option models bitwise operations exactly instead of using the default
 {term}`overapproximation`s. It is useful when the Prover reports a
@@ -1011,26 +977,22 @@ precisely: the maximum supported integer value is :math:`2^256-1` in this case,
 effectively restricting a `mathint` to a `uint256`. We currently do not have a
 setting or encoding that models precisely both bitwise operations and `mathint`.
 
-(-smt_groundQuantifiers)=
-#### `--prover_args -smt_groundQuantifiers=false`
+#### <a id="smt_groundQuantifiers"></a>`--prover_args -smt_groundQuantifiers=false`
 
 This option disables quantifier grounding.  See {ref}`grounding` for more
 information.
 
-(-maxNumberOfReachChecksBasedOnDomination)=
-#### `--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'`
+#### <a id="maxNumberOfReachChecksBasedOnDomination"></a>`--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'`
 
 This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
-(-enableStorageSplitting)=
-#### `--prover_args '-enableStorageSplitting false'`
+#### <a id="enableStorageSplitting"></a>`--prover_args '-enableStorageSplitting false'`
 
 This option disables the storage splitting optimization.
 
 
-(--allow_solidity_calls_in_quantifiers)=
-### `--allow_solidity_calls_in_quantifiers`
+### <a id="allow_solidity_calls_in_quantifiers"></a>`--allow_solidity_calls_in_quantifiers`
 
 **What does it do?**
 
@@ -1053,8 +1015,7 @@ Control flow splitting options
 
 See [here](control-flow-splitting) for an explanation of control flow splitting.
 
-(-depth)=
-### `--prover_args '-depth <number>'`
+### <a id="depth"></a>`--prover_args '-depth <number>'`
 
 **What does it do?**
 
@@ -1077,8 +1038,7 @@ The default value for this option is 10.
 certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-depth 5'
 ```
 
-(-mediumTimeout)=
-### `--prover_args '-mediumTimeout <seconds>'`
+### <a id="mediumTimeout"></a>`--prover_args '-mediumTimeout <seconds>'`
 
 The "medium timeout" determines how much time the SMT solver gets for checking a
 {term}`split` that is not a {term}`split leaf`.
@@ -1103,8 +1063,7 @@ a given depth.
 certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-mediumTimeout 20'
 ```
 
-(-dontStopAtFirstSplitTimeout)=
-### `--prover_args '-dontStopAtFirstSplitTimeout <true/false>'`
+### <a id="dontStopAtFirstSplitTimeout"></a>`--prover_args '-dontStopAtFirstSplitTimeout <true/false>'`
 
 **What does it do?**
 
@@ -1127,8 +1086,7 @@ The default value for this option is `false`.
 certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-dontStopAtFirstSplitTimeout true'
 ```
 
-(-smt_initialSplitDepth)=
-### `--prover_args '-smt_initialSplitDepth <number>'`
+### <a id="smt_initialSplitDepth"></a>`--prover_args '-smt_initialSplitDepth <number>'`
 
 With this option, the splitting can be configured to skip the SMT solver-based checks
 at low splitting levels, thus generating sub-{term}`split`s up to a given depth immediately.


### PR DESCRIPTION

- The motivation for this PR is that in the new dashboard we will see the list of flags used for the run and the user will be able to click on the flag name and get to the online documentation 
- The flag and the anchor should be the same to allow a generic link creation based on flag name


These flags have help message i.e. will appear in certoraRun --help but do not have documentation in certora web documentation.


PROTOCOL_NAME
PROTOCOL_AUTHOR
BUILD_CACHE
MULTI_EXAMPLE
FUNCTION_FINDER_MODE
VYPER
SOLC_EXPERIMENTAL_VIA_IR
SOLC_MAP
STRICT_SOLC_OPTIMIZER
YUL_ABI
TYPECHECKER_ARGS
IGNORE_SOLIDITY_WARNINGS
PROVER_VERSION
BYTECODE_JSONS

