### PR TITLE
Adding definition of Persistent Ghost

### DIFF
--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -194,6 +194,8 @@ Restrictions on ghost axioms
 Ghosts vs. persistent ghosts
 ----------------------------
 
+A `persistent ghost` is a `ghost` that will never be {ref}`havoc <glossary>`. This typically happens for unresolved calls, when the Prover will automatically {ref}`havoc <glossary>` the storage. 
+
 In most cases, non-persistent ghosts are the natural choice for a specification 
 that requires extra tracking of information.
 


### PR DESCRIPTION
In the current version of the documentation we fail to say explicitly what a persistent ghost is. This PR adds a short definition-

See also discussion around https://certora.slack.com/archives/CF2E0UR3L/p1718090375662839


