### PR TITLE
glossary entry for call trace (was: TODO)

### DIFF
--- a/docs/prover/changelog/report_changelog.md
+++ b/docs/prover/changelog/report_changelog.md
@@ -24,7 +24,7 @@ Rules Report Release Notes
 ### Features
 
 - [feat] Jump To Source: Animation to highlight already selected line on button click
-- [feat] New Job Configuration Tab that provides details on all arguments and inputs of a job that has been executed with (main contract, solidity version, all prover flags and CLI options)
+- [feat] New Job Configuration Tab that provides details on all arguments and inputs of a job that has been executed with (main contract, solidity version, all Prover flags and CLI options)
 - [feat] Browser tab title now indicates the main contract and the message of the job to simplify identification of a job
 - [feat] Files with extension `.yul` - [Yul files](https://docs.soliditylang.org/en/latest/yul.html) - can be displayed in the editor
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -9,7 +9,7 @@ axiom
 
 call trace
   A call trace is the Prover's visualization of either a 
-  {term}`counter example` or a {term}`witness example`. 
+  {term}`counterexample` or a {term}`witness example`. 
 
   A call trace illustrates a rule execution that leads up to the violation
   of an `assert` statement or the fulfillment of a `satisfy` statement. The
@@ -17,7 +17,7 @@ call trace
   was calling into), starting at the beginning of the rule and ending with the 
   violated `assert` or fulfilled `satisfy` statement.
   In addition to the commands, the call trace also does a best effort at 
-  showing information about the program state at each poin in the exexution.
+  showing information about the program state at each point in the execution.
   It contains information about the state of global variables at crucial points 
   as well as the values of call parameters, return values, and more.
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -12,11 +12,11 @@ call trace
   of an `assert` statement or the fulfillment of a `satisfy` statement. The
   trace is a sequence of nodes that correspond to commands in the rule (or in
   the contracts the rule was calling into), starting at the beginning of the 
-  rule and ending with the violated `assert` / fulfilled `satisfy` statement.
+  rule and ending with the violated `assert` or fulfilled `satisfy` statement.
   In addition to the commands, the call trace also contains information about
   the values of variables and expressions at each point in the execution.
   The purpose of a call trace is to give the users a means of understanding why 
-  the rule was violated/not violated.
+  the rule was violated, or not violated.
 
   The call trace can be found in the "Call Trace" tab in the report for each 
   rule for which it was generated.

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -16,8 +16,10 @@ call trace
   trace is a sequence of commands in the rule (or in the contracts the rule 
   was calling into), starting at the beginning of the rule and ending with the 
   violated `assert` or fulfilled `satisfy` statement.
-  In addition to the commands, the call trace also contains information about
-  the values of variables and expressions at each point in the execution.
+  In addition to the commands, the call trace also does a best effort at 
+  showing information about the program state at each poin in the exexution.
+  It contains information about the state of global variables at crucial points 
+  as well as the values of call parameters, return values, and more.
 
   If a call trace exists, it can be found in the "Call Trace" tab in the report 
   after selecting the corresponding (sub-)rule.

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -8,6 +8,9 @@ axiom
   a statement accepted as true without proof.
 
 call trace
+  A call trace is the Prover's visualization of either a 
+  {term}`counter example` or a {term}`witness example`. 
+
   A call trace illustrates a rule execution that leads up to the violation
   of an `assert` statement or the fulfillment of a `satisfy` statement. The
   trace is a sequence of nodes that correspond to commands in the rule (or in
@@ -16,9 +19,6 @@ call trace
   In addition to the commands, the call trace also contains information about
   the values of variables and expressions at each point in the execution.
 
-  Note that a call trace only exists for `assert`s that are violated, and for
-  `satisfy`s that are fulfilled. The purpose of the call trace is to give users
-  a means of understanding the reasons for each of these results.
   If a call trace exists, it can be found in the "Call Trace" tab in the report 
   after selecting the corresponding (sub-)rule.
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -8,7 +8,18 @@ axiom
   a statement accepted as true without proof.
 
 call trace
-  TODO
+  A call trace illustrates a rule execution that leads up to the violation
+  of an `assert` statement or the fulfillment of a `satisfy` statement. The
+  trace is a sequence of nodes that correspond to commands in the rule (or in
+  the contracts the rule was calling into), starting at the beginning of the 
+  rule and ending with the violated `assert` / fulfilled `satisfy` statement.
+  In addition to the commands, the call trace also contains information about
+  the values of variables and expressions at each point in the execution.
+  The purpose of a call trace is to give the users a means of understanding why 
+  the rule was violated/not violated.
+
+  The call trace can be found in the "Call Trace" tab in the report for each 
+  rule for which it was generated.
 
 CFG
 control flow graph

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -13,9 +13,9 @@ call trace
 
   A call trace illustrates a rule execution that leads up to the violation
   of an `assert` statement or the fulfillment of a `satisfy` statement. The
-  trace is a sequence of nodes that correspond to commands in the rule (or in
-  the contracts the rule was calling into), starting at the beginning of the 
-  rule and ending with the violated `assert` or fulfilled `satisfy` statement.
+  trace is a sequence of commands in the rule (or in the contracts the rule 
+  was calling into), starting at the beginning of the rule and ending with the 
+  violated `assert` or fulfilled `satisfy` statement.
   In addition to the commands, the call trace also contains information about
   the values of variables and expressions at each point in the execution.
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -15,11 +15,12 @@ call trace
   rule and ending with the violated `assert` or fulfilled `satisfy` statement.
   In addition to the commands, the call trace also contains information about
   the values of variables and expressions at each point in the execution.
-  The purpose of a call trace is to give the users a means of understanding why 
-  the rule was violated, or not violated.
 
-  The call trace can be found in the "Call Trace" tab in the report for each 
-  rule for which it was generated.
+  Note that a call trace only exists for `assert`s that are violated, and for
+  `satisfy`s that are fulfilled. The purpose of the call trace is to give users
+  a means of understanding the reasons for each of these results.
+  If a call trace exists, it can be found in the "Call Trace" tab in the report 
+  after selecting the corresponding (sub-)rule.
 
 CFG
 control flow graph


### PR DESCRIPTION
In the glossary, the "call trace" entry showed "TODO". Adding an actual entry.

Link to generated documentation: https://certora-certora-prover-documentation--274.com.readthedocs.build/en/274/docs/user-guide/glossary.html#term-call-trace

