### PR TITLE
CERT-6637: Add entry about receiveOrFallback in glossary

### DIFF
--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -181,6 +181,12 @@ quantified expression
   referred to as *quantified expressions*.  See {ref}`logic-exprs` for
   details about quantifiers in CVL.
 
+receiveOrFallback
+  A special function we introduce in every contract to model the behaviour of solidity
+  for calls with no data or that do not resolve to any contract function.
+  It will call the receive function if present for calls with no data, and otherwise the fallback function.
+  Shows up in the parametric rules or invariants, as well as in the call trace for such calls, written `<receiveOrFallback>()`.
+
 sanity
   ```{todo}
   This section is incomplete.  See {ref}`--rule_sanity` and {ref}`built-in-sanity` for partial information.

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -186,6 +186,7 @@ receiveOrFallback
   for calls with no data or that do not resolve to any contract function.
   It will call the receive function if present for calls with no data, and otherwise the fallback function.
   Shows up in the parametric rules or invariants, as well as in the call trace for such calls, written `<receiveOrFallback>()`.
+  See also [Solidity Documentation](https://docs.soliditylang.org/en/latest/contracts.html#fallback-function).
 
 sanity
   ```{todo}

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -182,7 +182,7 @@ quantified expression
   details about quantifiers in CVL.
 
 receiveOrFallback
-  A special function we introduce in every contract to model the behaviour of solidity
+  A special function we introduce in every contract to model the behavior of solidity
   for calls with no data or that do not resolve to any contract function.
   It will call the receive function if present for calls with no data, and otherwise the fallback function.
   Shows up in the parametric rules or invariants, as well as in the call trace for such calls, written `<receiveOrFallback>()`.

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -128,6 +128,7 @@ preprocess
 preprocessing
 prestate
 reachability
+receiveOrFallback
 reentrancy
 reentrant
 relatedly


### PR DESCRIPTION
Based on changes in https://github.com/Certora/EVMVerifier/pull/6226 for the display of that.

Naming convention:
 - PRs for features that are in design should have the "proposal" label
 - PRs for features that haven't landed yet should have the "future" label
 - PRs for upcoming releases should have the "release" label
 - PRs with new documentation for existing features should have the "existing feature" label

Before requesting review:
 - Make sure there is a ticket in the DOC board in Jira
 - Make sure CI is passing
   - Spell check failure may require adding backticks around code or updating `spelling_wordlist.txt`
   - See `README.md` for information about style and markdown syntax
   - If the CI Details link gives a 404, you need to log in to readthedocs.com
 - Add link to generated documentation here
   - you can find this by following the read the docs link from the CI check
 - Ask for help in #documentation

Jira ticket: TODO
Link to generated documentation: https://certora-certora-prover-documentation--284.com.readthedocs.build/en/284/docs/user-guide/glossary.html#term-receiveOrFallback

