### PR TITLE
document new unresolved call syntax

### DIFF
--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -217,7 +217,8 @@ unresolved function calls, but that may produce spurious counter examples.
 Catch unresolved-calls entries let the user refine the summary used for
 unresolved function calls.
 
-One can specify the scope for which the unresolved summary will apply. The options are:
+One can specify the scope (`unresolved external in <scope>`) for which the
+unresolved summary will apply. The options are:
 * `Contract.functionSignature()` for summarizing unresolved calls within this function
 * `_.functionSignature()` for summarizing unresolved calls within this function in any contract
 * `Contract._` for summarizing unresolved calls in any function of the given contract

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -195,31 +195,48 @@ shown in the web report can indicate whether a summary was applied.
 Example:
 ```cvl
 methods {
-   function _._ external => DISPATCH [
-      C.foo(uint),
-      _.bar(address), // Will resolve to all available functions with the signature "bar(address)", specifically Other.bar(address)
-      C._ // Will resolve to all functions in C, specifically C.foo(uint) and C.baz(bool)
-   ] default NONDET;
+    // Applies to all unresolved calls called within `C.foo()`
+    unresolved external in C.foo() => DISPATCH [
+        D.baz()
+    ] default HAVOC_ECF;
+
+    // Applies to all unresolved calls in the scene (except ones specified by more refined catch-unresolved-calls entries)
+    unresolved external in _._ => DISPATCH [
+        C.foo(uint),
+        _.bar(address), // Will resolve to all available functions with the signature "bar(address)", specifically Other.bar(address)
+        C._ // Will resolve to all functions in C, specifically C.foo(uint) and C.baz(bool)
+    ] default NONDET;
 }
 ```
 
-The catch unresolved-calls entry is a special type of summary declaration that
+Catch unresolved-calls entries are a special type of summary declaration that
 instructs the Prover to replace calls to unresolved external function calls
 with a specific kind of summary, dispatch list.
 By default, the Prover will use an {ref}`AUTO summary <auto-summary>` for
 unresolved function calls, but that may produce spurious counter examples.
-The catch unresolved-calls entry lets the user refine the summary used for
+Catch unresolved-calls entries let the user refine the summary used for
 unresolved function calls.
 
+One can specify the scope for which the unresolved summary will apply. The options are:
+* `Contract.functionSignature()` for summarizing unresolved calls within this function
+* `_.functionSignature()` for summarizing unresolved calls within this function in any contract
+* `Contract._` for summarizing unresolved calls in any function of the given contract
+* `_._` for summarizing all unresolved calls in the scene.
+
+If multiple catch unresolved-calls entries exist, the order of precedence is the
+order of the above list, from top to bottom.
+
 ```{note}
-Only one catch unresolved-calls entry is allowed per a specification file.
-When importing a specification with a catch unresolved-calls entry it will be
-included as part of the current specification, and cannot be overridden.
+If `C.foo` has a (resolved) external call to `D.bar`, and `D.bar` contains an
+unresolved call, a catch-unresolved-calls entry that applies to `C.foo` will
+_not_ be applied to this unresolved call - only an entry that matches `D.bar`
+will be used.
 ```
 
-A catch unresolved-calls entry can only be summarized with a dispatch list
+Catch unresolved-calls entries can only be summarized with a dispatch list
 summary (and a dispatch list summary is only applicable for a catch
-unresolved-calls entry).
+unresolved-calls entries).
+
 A dispatch list summary directs the Prover to consider each of the methods
 described in the list as possible candidates for this unresolved call.
 The Prover will choose dynamically, that is, for each potential run of the
@@ -671,9 +688,9 @@ For this case it could be useful for `DISPATCHER` summaries to also inline the
 
 ```{note}
 The most commonly used dispatcher mode is `DISPATCHER(true)`, because in almost
-all cases `DISPATCHER(false)` and `AUTO` report the same set of violations. Since 
+all cases `DISPATCHER(false)` and `AUTO` report the same set of violations. Since
 Certora CLI version 7.7.0 when using `_.someFunc() => DISPATCHER(true)` the Prover
-first tests that a method `someFunc()` exists in the scene, and if not will fail. 
+first tests that a method `someFunc()` exists in the scene, and if not will fail.
 Before this version, this may cause vacuous results.
 ```
 


### PR DESCRIPTION
Naming convention:
 - PRs for features that are in design should have the "proposal" label
 - PRs for features that haven't landed yet should have the "future" label
 - PRs for upcoming releases should have the "release" label
 - PRs with new documentation for existing features should have the "existing feature" label

Before requesting review:
 - Make sure there is a ticket in the DOC board in Jira
 - Make sure CI is passing
   - Spell check failure may require adding backticks around code or updating `spelling_wordlist.txt`
   - See `README.md` for information about style and markdown syntax
   - If the CI Details link gives a 404, you need to log in to readthedocs.com
 - Add link to generated documentation here
   - you can find this by following the read the docs link from the CI check
 - Ask for help in #documentation

Jira ticket: TODO
Link to generated documentation: https://certora-certora-prover-documentation--287.com.readthedocs.build/en/287/docs/cvl/methods.html#catch-unresolved-calls-entry

