### PR TITLE
Update types.md, using the wrong type

### DIFF
--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -145,7 +145,7 @@ caption: child.spec
 
 // valid types
 Parent.ParentFileType     valid1;
-Child .ParentFileType     valid2;
+Child .ChildFileType      valid2;
 Parent.ParentContractType valid3;
 
 // invalid types


### PR DESCRIPTION
since the user-defined types are not inherited, so the `Child.ParentFileType` is not valid. instead, we should use `Child.ChildFileType`
[link](https://docs.certora.com/en/latest/docs/cvl/types.html#id5)