### PR TITLE
remove merge indicators

### DIFF
--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -237,12 +237,8 @@ The possible patterns are:
    this signature on all available contracts (including the primary contract).
    Example: `_.bar(address)`
 3. Wildcard function - a pattern specifying a contract, and matches all
-<<<<<<< HEAD
-   external functions in specified contract.
-=======
    external functions in specified contract (This pattern will also include the
    contract's fallback if it's implemented).
->>>>>>> origin/master
    Example: `C._`
 
 For the default summary the user can choose one of: `HAVOC_ALL`, `HAVOC_ECF`,
@@ -671,9 +667,9 @@ For this case it could be useful for `DISPATCHER` summaries to also inline the
 
 ```{note}
 The most commonly used dispatcher mode is `DISPATCHER(true)`, because in almost
-all cases `DISPATCHER(false)` and `AUTO` report the same set of violations. Since 
+all cases `DISPATCHER(false)` and `AUTO` report the same set of violations. Since
 Certora CLI version 7.7.0 when using `_.someFunc() => DISPATCHER(true)` the Prover
-first tests that a method `someFunc()` exists in the scene, and if not will fail. 
+first tests that a method `someFunc()` exists in the scene, and if not will fail.
 Before this version, this may cause vacuous results.
 ```
 


### PR DESCRIPTION
Naming convention:
 - PRs for features that are in design should have the "proposal" label
 - PRs for features that haven't landed yet should have the "future" label
 - PRs for upcoming releases should have the "release" label
 - PRs with new documentation for existing features should have the "existing feature" label

Before requesting review:
 - Make sure there is a ticket in the DOC board in Jira
 - Make sure CI is passing
   - Spell check failure may require adding backticks around code or updating `spelling_wordlist.txt`
   - See `README.md` for information about style and markdown syntax
   - If the CI Details link gives a 404, you need to log in to readthedocs.com
 - Add link to generated documentation here
   - you can find this by following the read the docs link from the CI check
 - Ask for help in #documentation

Jira ticket: TODO
Link to generated documentation: TODO

