### PR TITLE
General expression summaries

### DIFF
--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -430,7 +430,7 @@ from the type declared in the `methods` block entry.
 Wildcard entries must not declare return types, because they may apply to
 multiple methods that return different types.  If a wildcard entry is summarized
 with a ghost or function summary, the summary must include an `expect` clause;
-see {ref}`experssion-summary` for more details.
+see {ref}`expression-summary` for more details.
 
 (cvl2-integer-types)=
 Changes to integer types

--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -430,7 +430,7 @@ from the type declared in the `methods` block entry.
 Wildcard entries must not declare return types, because they may apply to
 multiple methods that return different types.  If a wildcard entry is summarized
 with a ghost or function summary, the summary must include an `expect` clause;
-see {ref}`function-summary` for more details.
+see {ref}`experssion-summary` for more details.
 
 (cvl2-integer-types)=
 Changes to integer types

--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -324,7 +324,7 @@ There are also several built-in variables:
   * `nativeBalances` is a mapping of the native token balances, i.e. ETH for Ethereum.
     The balance of an `address a` can be expressed using `nativeBalances[a]`.
 
- * `calledContract` is only available in {ref}`function summaries <function-summary>`.
+ * `calledContract` is only available in {ref}`expression summaries <expression-summary>`.
    It refers to the receiver contract of a summarized method call.
 
  * `executingContract` is only available in {ref}`hooks <hooks>`.  It refers to

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -5,7 +5,7 @@ Ghosts
 Ghosts are a way of defining additional variables for use during verification.
 These variables are often used to 
 - communicate information between {ref}`rules-main` and {ref}`hooks`.
-- define deterministic {ref}`function summaries <function-summary>`.
+- define deterministic {ref}`expression summaries <expression-summary>`.
 
 Ghosts can be seen as an 'extension' to the state of the contracts under verification.
 This means that in case a call reverts, the ghost values will revert to their pre-state.

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -431,7 +431,7 @@ After the `optional` annotation, an entry may contain a `with(env e)` clause.
 The `with` clause introduces a new variable (`e` for `with(env e)`) to represent
 the {ref}`environment <env>` that is passed to a summarized function; the
 variable can be used in function summaries.  `with` clauses may only be used if
-the entry has a function summary. See {ref}`function-summary` below for more
+the entry has a function summary. See {ref}`expression-summary` below for more
 information about the environment provided by the `with` clause.
 
 

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -68,7 +68,7 @@ method_summary   ::= "ALWAYS" "(" value ")"
                    | "HAVOC_ALL"
                    | "DISPATCHER" [ "(" ( "true" | "false" ) ")" ]
                    | "AUTO"
-                   | id "(" [ id { "," id } ] ")" [ "expect" id ]
+                   | expr [ "expect" id ]
                    | "DISPATCH" "[" dispatch_list_pattern [","] | empty "]" "default" method_summary
 
 dispatch_list_patterns ::= dispatch_list_patterns "," dispatch_pattern
@@ -80,7 +80,7 @@ dispatch_pattern ::= | "_" "." id "(" evm_params ")"
 ```
 
 See {doc}`types` for the `evm_type` production.  See {doc}`basics`
-for the `id` production.  See {doc}`expr` for the `expression` production.
+for the `id` production.  See {doc}`expr` for the `expr` production.
 
 (methods-entries)=
 Methods entry patterns
@@ -444,7 +444,7 @@ There are several kinds of summaries available:
  - {ref}`dispatcher` assume that the receiver of the method call could be any
    contract that implements the method.
 
- - {ref}`function-summary` replace calls to the summarized method with {doc}`functions`
+ - {ref}`expression-summary` replace calls to the summarized method with a cvl expression, typically {doc}`functions`
    or {ref}`ghost-axioms`.
 
  - {ref}`auto-summary` are the default for unresolved calls.
@@ -706,12 +706,12 @@ The behavior of the `AUTO` summary depends on the type of call[^opcodes]:
   [State Mutability](https://docs.soliditylang.org/en/v0.8.12/contracts.html#state-mutability)
   in the Solidity manual for details.
 
-(function-summary)=
-#### Function summaries
+(expression-summary)=
+#### Expression summaries
 
-Contract methods can also be summarized using CVL {doc}`functions` or
+Contract methods can also be summarized using CVL expressions, typically {doc}`functions` or
 {ref}`ghost-axioms` as approximations.  Contract calls to the summarized method
-are replaced by calls to the specified CVL functions.
+are replaced by evaluation of the CVL expression.
 
 To use a CVL function or ghost as a summary, use a call to the function in
 place of the summary type.

--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -444,7 +444,7 @@ There are several kinds of summaries available:
  - {ref}`dispatcher` assume that the receiver of the method call could be any
    contract that implements the method.
 
- - {ref}`expression-summary` replace calls to the summarized method with a cvl expression, typically {doc}`functions`
+ - {ref}`expression-summary` replace calls to the summarized method with a CVL expression, typically {doc}`functions`
    or {ref}`ghost-axioms`.
 
  - {ref}`auto-summary` are the default for unresolved calls.

--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -336,7 +336,7 @@ When a specification calls a contract function, the Prover must convert the
 arguments from their CVL types to the corresponding Solidity types, and must
 convert the return values from Solidity back to CVL.  The Prover must also apply
 these conversions when inlining {ref}`hooks <hooks>` and {ref}`function
-summaries <function-summary>`.
+summaries <expression-summary>`.
 
 There are restrictions on what types can be converted from CVL to Solidity and
 vice-versa.  In general, if a contract uses a type that is not convertible, you
@@ -360,7 +360,7 @@ types:
    have [value types][solidity-value-types] that are representable in CVL.
 
 There are additional restrictions on the types for arguments and return values
-for internal function summaries; see {ref}`function-summary`.
+for internal function summaries; see {ref}`expression-summary`.
 
 [solidity-value-types]: https://docs.soliditylang.org/en/v0.8.11/types.html#value-types
 

--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -463,7 +463,7 @@ Minor improvements.
 
 #### CVL
 
-- Better expressivity: Allow binding the called contract in summaries using `calledContract` (see {ref}`function-summary`)
+- Better expressivity: Allow binding the called contract in summaries using `calledContract` (see {ref}`expression-summary`)
 - Ease of use: Support reading and passing complex array and struct types in CVL. For example, you can write now:
 ```cvl
 env e;


### PR DESCRIPTION
A very minimal way to not lie about the fact that we can have arbitrary expressions and not just function calls in the summaries. Multiple people seemed recently confused about that.

We could probably write more about it, but if the most prominent usecase still is to just call a function, I'm not sure we have to.