### PR TITLE
Document address function calls

### DIFF
--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -369,9 +369,9 @@ Another possible way to have the Prover consider options for a function is by
 prefixing the function name with an `address` typed variable. In this case the
 Prover will consider every possible contract in the scene that implements a
 function that matches the signature provided by the call (if no such function
-exists in the scene the prover will fail with an error). If there are no
+exists in the scene the Prover will fail with an error). If there are no
 constraints on the `address` variable that prevent the Prover from choosing a
-value that doesn't match the address of any contract in the scene, the prover
+value that doesn't match the address of any contract in the scene, the Prover
 will also consider this case and will consider it as a violation of the rule.
 
 (with-revert)=

--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -108,7 +108,7 @@ Struct Comparison
 CVL supports equality comparison of structs under the following restrictions:
 
  * The structs must be of the same type.
- * The structs (or any nested structs) don't contain dynamic arrays. (`string` and `bytes` can be part of the struct) 
+ * The structs (or any nested structs) don't contain dynamic arrays. (`string` and `bytes` can be part of the struct)
  * There's no support for comparison for structs fetched using direct-storage-access.
 
 Two structs will be evaluated as equal if and only if all the fields are equal.
@@ -349,9 +349,9 @@ There are many kinds of function-like things that can be called from CVL:
 There are several additional features that can be used when calling contract
 functions (including calling them through {ref}`method variables <method-type>`).
 
-The method name can optionally be prefixed by a contract name.  If a contract is
-not explicitly named, the method will be called with `currentContract` as the
-receiver.
+The method name can optionally be prefixed by a contract name (introduced via a
+{ref}`using statement <using-stmt>`). If a contract is not explicitly named, the
+method will be called with `currentContract` as the receiver.
 
 It is possible for multiple contract methods to match the method call.  This can
 happen in two ways:
@@ -364,6 +364,15 @@ In either case, the Prover will consider every possible resolution of the method
 while verifying the rule, and will provide a separate verification report for
 each checked method.  Rules that use this feature are referred to as
 {term}`parametric rule`s.
+
+Another possible way to have the Prover consider options for a function is by
+prefixing the function name with an `address` typed variable. In this case the
+Prover will consider every possible contract in the scene that implements a
+function that matches the signature provided by the call (if no such function
+exists in the scene the prover will fail with an error). If there are no
+relevant constraints on the `address` variable the prover may also consider the
+case that its value does not match any contract in the scene and in this case
+the Prover will consider this a violation of the rule.
 
 (with-revert)=
 After the function name, but before the arguments, you can write an optional
@@ -568,7 +577,7 @@ contract WithImmutables {
     return myImmutAddr;
   }
 }
-``` 
+```
 
 We can access both `myImmutAddr` and `myImmutBool` directly from CVL
 like this:
@@ -589,7 +598,7 @@ rule accessPublicImmut {
 }
 ```
 
-The advantages of direct immutable access is that there is no need to 
+The advantages of direct immutable access is that there is no need to
 declare `envfree` methods for the public immutables, and even more importantly, nor is there a need to harness contracts in order to
 expose the private immutables.
 

--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -370,9 +370,9 @@ prefixing the function name with an `address` typed variable. In this case the
 Prover will consider every possible contract in the scene that implements a
 function that matches the signature provided by the call (if no such function
 exists in the scene the prover will fail with an error). If there are no
-relevant constraints on the `address` variable the prover may also consider the
-case that its value does not match any contract in the scene and in this case
-the Prover will consider this a violation of the rule.
+constraints on the `address` variable that prevent the Prover from choosing a
+value that doesn't match the address of any contract in the scene, the prover
+will also consider this case and will consider it as a violation of the rule.
 
 (with-revert)=
 After the function name, but before the arguments, you can write an optional

--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -369,10 +369,9 @@ Another possible way to have the Prover consider options for a function is by
 prefixing the function name with an `address` typed variable. In this case the
 Prover will consider every possible contract in the scene that implements a
 function that matches the signature provided by the call (if no such function
-exists in the scene the Prover will fail with an error). If there are no
-constraints on the `address` variable that prevent the Prover from choosing a
-value that doesn't match the address of any contract in the scene, the Prover
-will also consider this case and will consider it as a violation of the rule.
+exists in the scene the prover will fail with an error).
+If there is a value of the `address` variable that does not match any contract
+address in the scene, the rule will be violated.
 
 (with-revert)=
 After the function name, but before the arguments, you can write an optional


### PR DESCRIPTION
Naming convention:
 - PRs for features that are in design should have the "proposal" label
 - PRs for features that haven't landed yet should have the "future" label
 - PRs for upcoming releases should have the "release" label
 - PRs with new documentation for existing features should have the "existing feature" label

Before requesting review:
 - Make sure there is a ticket in the DOC board in Jira
 - Make sure CI is passing
   - Spell check failure may require adding backticks around code or updating `spelling_wordlist.txt`
   - See `README.md` for information about style and markdown syntax
   - If the CI Details link gives a 404, you need to log in to readthedocs.com
 - Add link to generated documentation here
   - you can find this by following the read the docs link from the CI check
 - Ask for help in #documentation

Jira ticket: TODO
Link to generated documentation: TODO

