### PR TITLE
invoke_ syntax removed from the doc

### DIFF
--- a/docs/cvl/statements.md
+++ b/docs/cvl/statements.md
@@ -35,9 +35,6 @@ statement ::= type id [ "=" expr ] ";"
             | "return" [ expr ] ";"
 
             | function_call ";"
-            | "call" id "(" exprs ")" ";"
-            | "invoke_fallback" "(" exprs ")" ";"
-            | "invoke_whole" "(" exprs ")" ";"
             | "reset_storage" expr ";"
 
             | "havoc" id [ "assuming" expr ] ";"


### PR DESCRIPTION
Removed old syntax(`invoke_fallback`, `invoke_whole`, and `call`) from the [documentation](https://docs.certora.com/en/latest/docs/cvl/statements.html#syntax) as proposed on [Discord](https://discord.com/channels/795999272293236746/1283926719597908091).