### PR TITLE
added correct syntax for smt_groundQuantifiers after Jeffery Sholtz c…

### DIFF
--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -985,7 +985,7 @@ Prover.  `--prover_args` receives a string containing Prover-specific options, a
 set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_args` value must be quoted
 
 (-optimisticreturnsize)=
-#### `--prover_args '-optimisticReturnsize=true'`
+#### `--prover_args '-optimisticReturnsize true'`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
@@ -999,7 +999,7 @@ the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
 (-superoptimisticreturnsize)=
-#### `--prover_args '-superOptimisticReturnsize=true'`
+#### `--prover_args '-superOptimisticReturnsize true'`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1020,7 +1020,7 @@ effectively restricting a `mathint` to a `uint256`. We currently do not have a
 setting or encoding that models precisely both bitwise operations and `mathint`.
 
 (-smt_groundquantifiers)=
-#### `--prover_args -smt_groundQuantifiers=false`
+#### `--prover_args '-smt_groundQuantifiers false'`
 
 This option disables quantifier grounding.  See {ref}`grounding` for more
 information.


### PR DESCRIPTION
Fixed documentation for `--prover_args '-smt_groundQuantifiers false'`  (was `--prover_args -smt_groundQuantifiers=false`). Encountered by Jeffery Sholtz from Rareskills.
Along the way removed all other equality signs from all other `prover_args`

Link to generated documentation: https://certora-certora-prover-documentation--303.com.readthedocs.build/en/303/docs/prover/cli/options.html#id98

