### PR TITLE
Resolve merge conflict in methods.md

### DIFF
--- a/docs/cvl/methods.md
+++ b/docs/cvl/methods.md
@@ -68,12 +68,8 @@ method_summary   ::= "ALWAYS" "(" value ")"
                    | "HAVOC_ALL"
                    | "DISPATCHER" [ "(" ( "true" | "false" ) ")" ]
                    | "AUTO"
-<<<<<<< HEAD
-                   | expr [ "expect" id ]
-=======
                    | "ASSERT_FALSE"
-                   | id "(" [ id { "," id } ] ")" [ "expect" id ]
->>>>>>> origin/master
+                   | expr [ "expect" id ]
                    | "DISPATCH" "[" dispatch_list_pattern [","] | empty "]" "default" method_summary
 
 dispatch_list_patterns ::= dispatch_list_patterns "," dispatch_pattern


### PR DESCRIPTION
There was a merge conflict [introduced in this PR](https://github.com/Certora/Documentation/pull/291) that made it to the documentation [on this page](https://docs.certora.com/en/latest/docs/cvl/methods.html). This PR resolves the merge.

