### PR TITLE
Docs for sunbeam

### DIFF
--- a/docs/sunbeam/index.rst
+++ b/docs/sunbeam/index.rst
@@ -1,0 +1,17 @@
+Sunbeam: Formal Verification for Soroban
+========================================
+
+*Certora Sunbeam* enables formal verification of `Soroban`_ smart contracts.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   installation
+   troubleshooting
+
+
+.. Links
+   =====
+
+.. _Soroban: https://stellar.org/soroban

--- a/docs/sunbeam/installation.rst
+++ b/docs/sunbeam/installation.rst
@@ -21,7 +21,7 @@ Installing Sunbeam
 #. Next, install Python3.8.16 or newer on your machine.
    If you already have Python3 installed, you can check the version: ``python3 --version``.
    If you need to upgrade, follow these instructions in the
-   `Python Begginers Guide <https://wiki.python.org/moin/BeginnersGuide/Download>`_.
+   `Python Beginners Guide <https://wiki.python.org/moin/BeginnersGuide/Download>`_.
 #. Next, install Java. Check your Java version: ``java -version``.
    If the version is < 11, download and install Java version 11 or later from
    `Oracle <https://www.oracle.com/java/technologies/downloads/>`_.
@@ -32,7 +32,7 @@ Installing Sunbeam
 #. Recall that you received a *Certora Key* in your email (Step 2).
    Use the key to set a temporary environment variable like so
    ``export CERTORAKEY=<personal_access_key>``.
-   Alternative, store the key in your profile see
+   Alternatively, to store the key in your profile see
    :ref:`Step 3 of the Prover installation <installation-step-3>`.
 
 
@@ -55,3 +55,6 @@ Rust and Stellar CLI Setup
 ----
 
 With that, you should be all set for using Certora Sunbeam. Congratulations!
+
+To learn more about using Certora Sunbeam, check out the
+`Sunbeam Tutorials <https://certora-sunbeam-tutorials.readthedocs-hosted.com/en/latest/>`_.

--- a/docs/sunbeam/installation.rst
+++ b/docs/sunbeam/installation.rst
@@ -1,0 +1,57 @@
+Installation
+============
+
+.. attention::
+
+   These instructions are for Linux and macOS systems.
+   Windows users should use `WSL`_ and follow the
+   Linux installation instructions.
+
+.. _WSL: https://learn.microsoft.com//install
+
+   
+Installing Sunbeam
+------------------
+
+#. First, we will need to install the Sunbeam Prover.
+   For that, please visit `Certora.com <https://www.certora.com/>`_ and sign up for a
+   free account at `Certora sign-up page <https://www.certora.com/signup>`_.
+#. You will receive an email with a temporary password and a *Certora Key*.
+   Use the password to login to Certora following the link in the email.
+#. Next, install Python3.8.16 or newer on your machine.
+   If you already have Python3 installed, you can check the version: ``python3 --version``.
+   If you need to upgrade, follow these instructions in the
+   `Python Begginers Guide <https://wiki.python.org/moin/BeginnersGuide/Download>`_.
+#. Next, install Java. Check your Java version: ``java -version``.
+   If the version is < 11, download and install Java version 11 or later from
+   `Oracle <https://www.oracle.com/java/technologies/downloads/>`_.
+#. Then, install the Certora Prover: ``pip3 install certora-cli-beta``.
+
+   .. tip:: Always use a Python virtual environment when installing packages.
+
+#. Recall that you received a *Certora Key* in your email (Step 2).
+   Use the key to set a temporary environment variable like so
+   ``export CERTORAKEY=<personal_access_key>``.
+   Alternative, store the key in your profile see
+   :ref:`Step 3 of the Prover installation <installation-step-3>`.
+
+
+Rust and Stellar CLI Setup
+--------------------------
+
+#. We recommend installing Rust as on the
+   `official Rust website <https://www.rust-lang.org/tools/install>`_: 
+   ``curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh``
+#. Next, install the WASM target like so: ``rustup target add wasm32-unknown-unknown``
+#. We recommend setting up the Stellar CLI as shown
+   `here <https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli>`_.
+#. We also recommend installing the `wabt <https://github.com/WebAssembly/wabt>`_ toolkit. 
+   ``wasm2wat`` is a useful tool for converting the WASM bytecode to a human readable format.
+   Ensure that ``wasm2wat`` is executable as a command from your terminal.
+   You will have to add ``wabt/bin`` to your ``PATH`` by running
+   ``export PATH=~/path/to/wabt/bin:$PATH``. 
+#. Finally, install ``rustfilt`` like so: ``cargo install rustfilt``.
+
+----
+
+With that, you should be all set for using Certora Sunbeam. Congratulations!

--- a/docs/sunbeam/troubleshooting.rst
+++ b/docs/sunbeam/troubleshooting.rst
@@ -1,0 +1,58 @@
+Troubleshooting
+===============
+
+Unable to run certoraRun
+------------------------
+If you are unable to run ``certoraRun``, we recommend trying it from within a ``venv``.
+
+#. First, create a ``venv`` and make sure you are inside the ``venv`` by running the
+   following:
+
+   .. code-block:: bash
+
+      cd meridian2024-workshop
+      python3 -m venv .venv
+      source .venv/bin/activate
+
+#. Then, install all required packages like so:
+
+   .. code-block:: bash
+
+      pip3 install -r requirements.txt
+
+#. Finally, try running certoraRun again:
+
+   .. code-block:: bash
+
+      certoraRun confs/setup.conf
+
+----
+
+Build step of certoraRun is failing
+-----------------------------------
+
+When you execute ``certoraRun``, the project is internally build using ``cargo build``.
+This step requires a successful build. In case ``certoraRun`` fails on the build step,
+first try to compile the project by running
+``cargo build --release --target wasm32-unknown-unknown``
+and resolve all compiler errors that you see.
+
+----
+
+Compiler Error: "error: linking with \`cc\` failed: exit status: 1" on Mac
+--------------------------------------------------------------------------
+
+If you are running on Mac and the build step of your project or ``certoraRun`` fails
+with the warning:
+
+.. code-block:: bash
+
+   "error: linking with \`cc\` failed: exit status: 1"
+
+then check out the following `StackOverflow post`_.
+
+.. Links
+   =====
+
+.. _StackOverflow post:
+   https://stackoverflow.com/questions/28124221/error-linking-with-cc-failed-exit-code-1

--- a/docs/sunbeam/troubleshooting.rst
+++ b/docs/sunbeam/troubleshooting.rst
@@ -1,8 +1,8 @@
 Troubleshooting
 ===============
 
-Unable to run certoraRun
-------------------------
+Unable to run ``certoraRun``
+----------------------------
 If you are unable to run ``certoraRun``, we recommend trying it from within a ``venv``.
 
 #. First, create a ``venv`` and make sure you are inside the ``venv`` by running the
@@ -20,7 +20,7 @@ If you are unable to run ``certoraRun``, we recommend trying it from within a ``
 
       pip3 install -r requirements.txt
 
-#. Finally, try running certoraRun again:
+#. Finally, try running ``certoraRun`` again:
 
    .. code-block:: bash
 
@@ -28,8 +28,8 @@ If you are unable to run ``certoraRun``, we recommend trying it from within a ``
 
 ----
 
-Build step of certoraRun is failing
------------------------------------
+Build step of ``certoraRun`` is failing
+---------------------------------------
 
 When you execute ``certoraRun``, the project is internally build using ``cargo build``.
 This step requires a successful build. In case ``certoraRun`` fails on the build step,

--- a/docs/user-guide/install.md
+++ b/docs/user-guide/install.md
@@ -5,23 +5,6 @@
 Installation
 ============
 
-```{note}
-We are excited to offer you early access to the Sunbeam tool for verifying [Soroban]
-smart contracts. For detailed instructions on installing and using Sunbeam, please see our [tutorial].
-Note that Sunbeam is still under active development and will continue to evolve and improve!
-```
-
-[Soroban]: https://stellar.org/soroban
-[tutorial]: https://github.com/Certora/meridian2024-workshop/blob/main/README.md
-
-```{attention}
-These instructions are for Linux and macOS systems.
-Windows users should use [WSL][wsl] and follow the
-Linux installation instructions.
-```
-
-[wsl]: https://learn.microsoft.com/en-us/windows/wsl/install
-
 Step 1: prerequisites
 ---------------------
 
@@ -214,6 +197,7 @@ pip3 install certora-cli-beta
 You can then switch to the standard CVL release by running `deactivate`, and
 back to the beta release using `certora-beta/bin/activate`.
 
+(installation-step-3)=
 Step 3: Set the personal access key as an environment variable
 -------------------------------------------------------------
 

--- a/index.rst
+++ b/index.rst
@@ -9,7 +9,7 @@ Contents
 * :doc:`docs/cvl/index` -- a reference manual for CVL.
 * :doc:`docs/prover/index` -- a reference manual for the Certora Prover.
 * :doc:`docs/sunbeam/index` -- instructions for installing and using *Certora Sunbeam*
-  for formal verification of Soroban contracts.
+  for formal verification of `Soroban`_ contracts.
 * :doc:`docs/gambit/index` -- use mutation testing to improve you specifications.
 
 .. toctree::
@@ -27,11 +27,18 @@ Contents
 Learning resources
 ------------------
 
+Certora Prover
+^^^^^^^^^^^^^^
+
 * :doc:`docs/user-guide/index` (in this Documentation).
 * `Certora Prover Tutorials`_ -- learning to use the Prover and CVL through exercises.
 * `Certora Prover and CVL Examples Repository`_ -- learn CVL from examples.
 * :doc:`docs/user-guide/tutorials` -- lists workshops and tutorials that
   cover basic Prover usage.
+
+Certora Sunbeam
+^^^^^^^^^^^^^^^
+* `Certora Sunbeam Tutorials`_ -- a set of exercises using Soroban contracts in Rust.
 
 
 .. Advanced topics
@@ -77,8 +84,12 @@ For sales, please use the `contact form on our website`_.
    -----
 .. _Certora Prover Tutorials: https://docs.certora.com/projects/tutorials
 .. _Certora Prover and CVL Examples Repository: https://github.com/Certora/Examples/
+.. _Certora Sunbeam Tutorials:
+   https://certora-sunbeam-tutorials.readthedocs-hosted.com/en/latest/
 
 .. _Help Desk channel on Discord:
    https://discord.com/channels/795999272293236746/1104825071450718338
 
 .. _contact form on our website: https://www.certora.com/#Request_Early_Access
+
+.. _Soroban: https://stellar.org/soroban

--- a/index.rst
+++ b/index.rst
@@ -8,9 +8,9 @@ Contents
   contracts. Organized by topic and focuses on the most useful features.
 * :doc:`docs/cvl/index` -- a reference manual for CVL.
 * :doc:`docs/prover/index` -- a reference manual for the Certora Prover.
-* :doc:`docs/gambit/index` -- use mutation testing to improve you specifications.
 * :doc:`docs/sunbeam/index` -- instructions for installing and using *Certora Sunbeam*
   for formal verification of Soroban contracts.
+* :doc:`docs/gambit/index` -- use mutation testing to improve you specifications.
 
 .. toctree::
    :maxdepth: 1

--- a/index.rst
+++ b/index.rst
@@ -20,8 +20,8 @@ Contents
    docs/user-guide/index.md
    docs/cvl/index.md
    docs/prover/index.md
-   docs/gambit/index.md
    docs/sunbeam/index.rst
+   docs/gambit/index.md
 
 
 Learning resources

--- a/index.rst
+++ b/index.rst
@@ -9,6 +9,8 @@ Contents
 * :doc:`docs/cvl/index` -- a reference manual for CVL.
 * :doc:`docs/prover/index` -- a reference manual for the Certora Prover.
 * :doc:`docs/gambit/index` -- use mutation testing to improve you specifications.
+* :doc:`docs/sunbeam/index` -- instructions for installing and using *Certora Sunbeam*
+  for formal verification of Soroban contracts.
 
 .. toctree::
    :maxdepth: 1
@@ -19,6 +21,7 @@ Contents
    docs/cvl/index.md
    docs/prover/index.md
    docs/gambit/index.md
+   docs/sunbeam/index.rst
 
 
 Learning resources


### PR DESCRIPTION
# Initial Sunbeam docs
Adds:
- Installation instructions
- Troubleshooting


Link to generated documentation: https://docs.certora.com/en/shoham-sunbeam-init/index.html
The new section: https://docs.certora.com/en/shoham-sunbeam-init/docs/sunbeam/index.html

