### PR TITLE
Typo Update mutation-verifier.md

### DIFF
--- a/docs/gambit/mutation-verifier.md
+++ b/docs/gambit/mutation-verifier.md
@@ -98,7 +98,7 @@ Mutations can either be randomly generated via {doc}`Gambit <gambit>`, or manual
 
 ### Randomly generated mutations via Gambit
 
-To generated random mutations via {doc}`Gambit <gambit>`, 
+To generate random mutations via {doc}`Gambit <gambit>`, 
   add a `gambit` key inside the `mutations` object. 
 This key should include a list of {ref}`Gambit mutation objects <gambit-config>`. 
 All file paths are relative to the current working directory.


### PR DESCRIPTION
**There is a typo in this doc:**

In the section "Randomly generated mutations via Gambit," the sentence:

> To **generated** random mutations via {doc}`Gambit <gambit>`, 

Should be:

> To **generate** random mutations via {doc}`Gambit <gambit>`, 

The word "generated" replaced with "**generate**," as it should be in the infinitive form following "To."

I’m practically a fan of Certora at this point! I admire how they’ve structured their documentation and tools, but even the best of us can slip up occasionally 😄
