### PR TITLE
Uri/rule report changelog 7.22.1

### DIFF
--- a/docs/prover/changelog/gui_changelog.md
+++ b/docs/prover/changelog/gui_changelog.md
@@ -4,7 +4,7 @@ GUI Release Notes
 ```{contents}
 ```
 
-3.1.0 (Jan 9, 2025)
+3.1.1 (Jan 9, 2025)
 ---------------------------
 
 ### Features

--- a/docs/prover/changelog/gui_changelog.md
+++ b/docs/prover/changelog/gui_changelog.md
@@ -8,9 +8,11 @@ GUI Release Notes
 ---------------------------
 
 ### Features
+
 - [feat] Support for displaying numeric values in string, decimal, or hexadecimal formats in Call Trace and Variables tabs, with a dropdown to switch formats.
 - [feat] Persist column configuration (display selection and width) across browser sessions on the Prover Dashboard, including between tabs and logins.
 - [feat] Added call traces and TAC dumps for sanity rules in Rule Report.
+
 
 3.0.2 (Nov 18, 2024)
 ---------------------------
@@ -20,8 +22,10 @@ GUI Release Notes
 - [feat] Improved formatting of the call trace: The call trace highlights values of the counter examples as gray boxes and provides tooltips indicating the semantics of the value (e.g. if the value is a return value or a parameter of a function call).
 - [feat] The rule tree automatically opens a node if it only contains a single child element. This reduces the number of user interactions required to get to the call trace and find the counter example.
 
+
 2.4.4 (Nov 6, 2024)
 ---------------------------
+
 ### Features
 
 - [feat] Adding support for syntax highlighting of Rust files in the code editor
@@ -30,6 +34,7 @@ GUI Release Notes
 ### Fixed Bugs
 
 - [bug] The re-run button was reported to not function for non-Certora users. This has been fixed.
+
 
 2.4.1 (Oct 6, 2024)
 ---------------------------
@@ -55,6 +60,7 @@ GUI Release Notes
 
 - [feat] Job execution status in browser tab
 
+
 2.1.6 (Jul 8, 2024)
 ---------------------------
 
@@ -79,6 +85,7 @@ GUI Release Notes
 - [fix] Expansion bug on the main UI grid
 - [fix] Fixes for the call trace tracking points
 
+
 1.0.0 (Apr 11, 2024)
 ---------------------------
 
@@ -92,6 +99,7 @@ GUI Release Notes
 ### Fixed Bugs
 
 - [fix] When a job has been canceled or halted, only rules that were running are being displayed as killed 
+
   
 0.8.0 (Mar 11, 2024)
 ---------------------------
@@ -135,6 +143,7 @@ GUI Release Notes
 ### Features
 
 - [feat] Improvements on naming for global / rule notifications
+
 
 0.5.62 (Feb 11, 2024)
 ---------------------------

--- a/docs/prover/changelog/gui_changelog.md
+++ b/docs/prover/changelog/gui_changelog.md
@@ -4,7 +4,7 @@ GUI Release Notes
 ```{contents}
 ```
 
-3.1.1 (Jan 9, 2025)
+3.1.1 (Jan 12, 2025)
 ---------------------------
 
 ### Features

--- a/docs/prover/changelog/gui_changelog.md
+++ b/docs/prover/changelog/gui_changelog.md
@@ -1,4 +1,4 @@
-Rules Report Release Notes
+GUI Release Notes
 =============
 
 ```{contents}

--- a/docs/prover/changelog/gui_changelog.md
+++ b/docs/prover/changelog/gui_changelog.md
@@ -4,6 +4,14 @@ GUI Release Notes
 ```{contents}
 ```
 
+3.1.0 (Jan 9, 2025)
+---------------------------
+
+### Features
+- [feat] Support for displaying numeric values in string, decimal, or hexadecimal formats in Call Trace and Variables tabs, with a dropdown to switch formats.
+- [feat] Persist column configuration (display selection and width) across browser sessions on the Prover Dashboard, including between tabs and logins.
+- [feat] Added call traces and TAC dumps for sanity rules in Rule Report.
+
 3.0.2 (Nov 18, 2024)
 ---------------------------
 

--- a/docs/prover/changelog/index.md
+++ b/docs/prover/changelog/index.md
@@ -6,5 +6,5 @@ Changelog
 :caption: Contents
 
 prover_changelog.md
-report_changelog.md
+gui_changelog.md
 ```

--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -5,7 +5,7 @@ Prover Release Notes
 ```{contents}
 ```
 
-7.22.2 (Jan 9, 2025)
+7.22.2 (Jan 12, 2025)
 ----------------------
 ### Rule Report
 - [feat] Support for displaying numeric values in string, decimal, or hexadecimal formats in Call Trace and Variables tabs, with a dropdown to switch formats.

--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -5,6 +5,16 @@ Prover Release Notes
 ```{contents}
 ```
 
+7.22.2 (Jan 9, 2025)
+----------------------
+### Rule Report
+- [feat] Support for displaying numeric values in string, decimal, or hexadecimal formats in Call Trace and Variables tabs, with a dropdown to switch formats.
+- [feat] Added call traces and TAC dumps for sanity rules in Rule Report.
+
+## Dashboard
+- [feat] Persist column configuration (display selection and width) across browser sessions on the Prover Dashboard, including between tabs and logins.
+
+
 7.21.1 (December 12, 2024)
 ----------------------
 Various bug fixes and performance improvements.

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -70,6 +70,7 @@ dispatchee
 dispatchees
 downsample
 downsampling
+dropdown
 eBPF
 enum
 enums


### PR DESCRIPTION
- Added log for the new FE version
- Renamed the rule report changelog to GUI changelog, to reflect that it also includes dashboard changes

Link to generated documentation: https://certora-certora-prover-documentation--326.com.readthedocs.build/en/326/docs/prover/changelog/gui_changelog.html#jan-9-2025

