### PR TITLE
document `--project_sanity` and `--foundry`

### DIFF
--- a/docs/cvl/foundry-integration.md
+++ b/docs/cvl/foundry-integration.md
@@ -1,3 +1,4 @@
+(foundry_integration)=
 Foundry Integration (Alpha)
 =================
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -369,6 +369,26 @@ may be hot spots for summarization etc.
 **Example**
 `certoraRun --project_sanity`
 
+(--foundry)=
+### `--foundry`
+
+**What does it do?**
+Collects all test files in the project (files ending with `.t.sol`), and runs
+the {ref}`foundry_integration` on them (specifically, the
+`verifyFoundryFuzzTestsNoRevert` builtin rule). As with the
+{ref}`--project_sanity` option, the search is over files in the current git
+repository if such exists, otherwise over all files in the tree under the
+current working directory.
+
+Note - this option implicitly enables the {ref}`--auto_dispatcher` option.
+
+
+**When to use it?**
+When we want to run all foundry fuzz tests in the project with the prover.
+
+**Example**
+`certoraRun --foundry`
+
 Options that control the Solidity compiler
 ------------------------------------------
 (--compiler_map)=

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -351,13 +351,13 @@ When we do not care much for the output. It is recommended when running the tool
 
 **What does it do?**
 Runs the builtin sanity rule on all methods in the project. If the Prover is run
-from within a git project, all .sol files in the in the git repository are added
+from within a git project, all `.sol` files in the in the git repository are added
 to the scene and the {ref}`builtin sanity rule <built-in-sanity>` is run on
-them. Otherwise, _all_ .sol files in the tree under the current working
+them. Otherwise, _all_ `.sol` files in the tree under the current working
 directory are collected.
 
-Alternatively, a list of files could be provided and then the builtin sanity
-rule will run on all methods of the specified files.
+Alternatively, a list of files can be provided in the `.conf` file and then the
+builtin sanity rule will run on all methods of the specified files.
 
 Note - this option implicitly enables the {ref}`--auto_dispatcher` option.
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -335,7 +335,6 @@ useful check if you notice rules passing surprisingly quickly or easily.
 `certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity basic`
 
 (--short_output)=
-
 ### `--short_output`
 
 **What does it do?**
@@ -346,6 +345,29 @@ When we do not care much for the output. It is recommended when running the tool
 
 **Example**
 `certoraRun Bank.sol --verify Bank:Bank.spec --short_output`
+
+(--project_sanity)=
+### `--project_sanity`
+
+**What does it do?**
+Runs the builtin sanity rule on all methods in the project. If the Prover is run
+from within a git project, all .sol files in the in the git repository are added
+to the scene and the {ref}`builtin sanity rule <built-in-sanity>` is run on
+them. Otherwise, _all_ .sol files in the tree under the current working
+directory are collected.
+
+Alternatively, a list of files could be provided and then the builtin sanity
+rule will run on all methods of the specified files.
+
+Note - this option implicitly enables the {ref}`--auto_dispatcher` option.
+
+**When to use it?**
+Mostly used as a first step when starting to work on a new project, in order to
+"get a feeling" of the complexity of the project for the tool, and what methods
+may be hot spots for summarization etc.
+
+**Example**
+`certoraRun --project_sanity`
 
 Options that control the Solidity compiler
 ------------------------------------------


### PR DESCRIPTION
Note this is sitting on top of https://github.com/Certora/Documentation/pull/344 since it references the `--auto_dispatcher` option.

Link to generated documentation: https://certora-certora-prover-documentation--347.com.readthedocs.build/en/347/docs/prover/cli/options.html#project-sanity

