### PR TITLE
Foundry Integration Doc Updates

### DIFF
--- a/docs/cvl/foundry-integration.md
+++ b/docs/cvl/foundry-integration.md
@@ -14,7 +14,17 @@ This feature of the Certora Prover is in alpha state, so issues/unimplemented fe
 any issue.
 ```
 
-# Usage
+# Usage (Automatic Setup)
+
+In Prover version 7.25.1, the flag {ref}`--foundry` was introduced. This flag will automatically collects all test files (`.t.sol`) in the current directory.
+
+To execute use: 
+`certoraRun --foundry`
+
+If you are facing issues with the automatic setup, for instance, when too many contracts that are being analyzed, 
+it is recommended to perform a manual setup instead.
+
+# Usage (Manual Setup)
 
 There is a minimum of 2 required files to get the Prover to verify Foundry fuzz tests: A `.spec` file (written in CVL), and a `.conf` file. 
 
@@ -65,24 +75,6 @@ storage fields of a contract to `0` before running the test. Alternatively, one 
 `init_fuzz_tests` function - please note that the `init_fuzz_tests` is an empty method by default.
 
 # Known Limitations 
-
-- The call trace of the Foundry integration can be hard to read when there is more than one Foundry test method in a job. When focusing on a particular violation 
-of a fuzz test method it is helpful to use the `--method "<FUZZ_TEST_METHOD_NAME>"` [flag](https://docs.certora.com/en/latest/docs/prover/cli/options.html#method-method-signature).\
-\
-The rule `verifyFoundryFuzzTests` is implemented as a parametric rule with parameter `method f` followed by a statement `if(f.selector == <FuzzTestMethod>.selector)`
-for each detected fuzz method. The actual code of the fuzz test method starts within the `Then` block of the condition that evaluated to `true`.\
-\
-Here is an example of a call trace of a job that was run _without_ the `--method` flag ([Link to job](https://prover.certora.com/output/15800/70e5d5141ce34e4eae0f9966b78b34d9?anonymousKey=40a3a0266ff277d769a873681b1fc7829b0b5c55)).\
-\
-![Foundry Integration - Complex Call Trace](foundry-integration-complex-call-trace.png)\
-\
-Say the user selected `test_percentMul_fuzz_no_expectRevert(uint256 value, uint256 percentage)` in the rules panel to the left. Observe that in the call trace 
-there is an entry `f.selector == (sig:PercentageMathTests.test_percentMul_fuzz_no_expectRevert(uint256 value, uint256 percentage)).selector ↪ true` and a 
-then block `Then(cvlRange=Fuzz.t.spec:1:1)`. The method has been inlined within the then block, here you can find the parameter assignments that lead to the violation.\
-\
-If you run the same example the flag `--method "test_percentMul_fuzz_wrong_assert(uint256,uint256)"` ([Link to job](https://prover.certora.com/output/53900/0efb4c7272774df886203375b490300a?anonymousKey=5f95f5d1c2a0b8aac88cd6d5842e577707238747)), the call trace is significantly simpler.
-![Foundry Integration - Simpler Call Trace](foundry-integration-simple-call-trace.png)
-
 
 - Foundry's [Invariant testing](https://book.getfoundry.sh/forge/invariant-testing) is not supported, i.e. forge tests prefixed with 
 `invariant` are not formally verified. Under the hood, the built-in rule `verifyFoundryFuzzTests` is a parametric rule that picks up all methods 

--- a/docs/cvl/foundry-integration.md
+++ b/docs/cvl/foundry-integration.md
@@ -17,7 +17,7 @@ any issue.
 
 # Usage (Automatic Setup)
 
-In Prover version 7.25.1, the flag {ref}`--foundry` was introduced. This flag automatically collects all test files (`.t.sol`) in the current directory and executes the Prover in foundry mode. 
+In Prover version 7.25.1, the flag {ref}`--foundry` was introduced. This flag automatically collects all test files (`.t.sol`) in the current directory and executes the Prover in Foundry mode. 
 
 To execute use: 
 `certoraRun --foundry`

--- a/docs/cvl/foundry-integration.md
+++ b/docs/cvl/foundry-integration.md
@@ -16,7 +16,7 @@ any issue.
 
 # Usage (Automatic Setup)
 
-In Prover version 7.25.1, the flag {ref}`--foundry` was introduced. This flag will automatically collects all test files (`.t.sol`) in the current directory.
+In Prover version 7.25.1, the flag {ref}`--foundry` was introduced. This flag automatically collects all test files (`.t.sol`) in the current directory and executes the Prover in foundry mode. 
 
 To execute use: 
 `certoraRun --foundry`


### PR DESCRIPTION
This PR just updates the current foundry integration for the current release by removing an outdated limitation around the complexity of the call trace and by stating the new `--foundry` flag. 
