### PR TITLE
first pass

### DIFF
--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -4,7 +4,7 @@ Prover Release Notes
 
 ```{contents}
 ```
-7.25.1 (Feb 19, 2025)
+7.25.2 (Feb 19, 2025)
 ----------------------
 ### CVL
 - [feat] CVL now supports native summation over ghost mapping variables with the new `sum` and `usum` keywords.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -58,7 +58,9 @@ To create the message above, we used
 ### `--rule`
 
 **Usage**
-`--rule <rule_name_pattern>...`
+```
+--rule <rule_name_pattern>...
+```
 
 **What does it do?**
 Formally verifies one or more given properties instead of the whole specification file. An invariant can also be selected.
@@ -94,7 +96,9 @@ simply run `certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*`
 ### `--exclude_rule`
 
 **Usage**
-`--exclude_rule <rule_name_pattern>...`
+```
+--exclude_rule <rule_name_pattern>...
+```
 
 **What does it do?**
 It is the opposite flag to {ref}`--rule` - use it to specify a list of rules that
@@ -116,7 +120,9 @@ If we want to skip both rules we could run
 ### `--split_rules`
 
 **Usage**
-`--split_rules <rule_name_pattern>...`
+```
+--split_rules <rule_name_pattern>...
+```
 
 **What does it do?**
 Typically, all rules (after being filtered by {ref}`--rule` and {ref}`--exclude_rule`) are evaluated in a single Prover job.
@@ -661,7 +667,9 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 ### `--nondet_minimal_difficulty`
 
 **Usage**
-`--nondet_minimal_difficulty <n>`
+```
+--nondet_minimal_difficulty <n>
+```
 
 **What does it do?**
 This option sets the minimal difficulty threshold for the auto-summarization mode enabled by {ref}`--nondet_difficult_funcs`.
@@ -725,7 +733,9 @@ _could_ actually happen in the deployed contract, this code-path won't be verifi
 ### `--summary_recursion_limit`
 
 **Usage**
-`--summary_recursion_limit <n>`
+```
+--summary_recursion_limit <n>
+```
 
 **What does it do?**
 Summaries can cause recursion (see {ref}`--optimistic_summary_recursion`). This
@@ -787,7 +797,9 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 ### `--hashing_length_bound`
 
 **Usage**
-`--hashing_length_bound <n>`
+```
+--hashing_length_bound <n>
+```
 
 **What does it do?**
 
@@ -876,7 +888,9 @@ processing of the entire job, including static analysis and other
 preprocessing.
 
 **Usage**
-`--global_timeout <seconds>`
+```
+--global_timeout <seconds>
+```
 
 **When to use it?**
 When running on just a few rules, or when willing to make faster iterations on specs without waiting too long for the entire set of rules to complete.
@@ -893,7 +907,9 @@ See {ref}`--method`
 ### `--smt_timeout`
 
 **Usage**
-`--smt_timeout <seconds>`
+```
+--smt_timeout <seconds>
+```
 
 **What does it do?**
 Sets the maximal timeout for all the
@@ -982,7 +998,9 @@ contract already has such a function and this would cause a conflict).
 ### `--contract_recursion_limit`
 
 **Usage**
-`--contract_recursion_limit <n>`
+```
+--contract_recursion_limit <n>
+```
 
 **What does it do?**
 Contract inlining can cause recursion (see {ref}`--optimistic_contract_recursion`). This
@@ -1025,7 +1043,9 @@ certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 ### `--link`
 
 **Usage**
-`--struct_link <contract>:<slot>=<address>`
+```
+--struct_link <contract>:<slot>=<address>
+```
 
 **What does it do?**
 Links a slot in a contract with another contract.
@@ -1078,7 +1098,9 @@ calls with an empty input buffer will {term}`havoc` all the storage state of ext
 ### `--struct_link`
 
 **Usage**
-`--struct_link <contract>:<slot>=<address>`
+```
+--struct_link <contract>:<slot>=<address>
+```
 
 **What does it do?**
 Links a slot in a struct with another contract. To do that you must calculate the slot number of the field you wish to replace.
@@ -1108,7 +1130,9 @@ Options for controlling contract creation
 ### `--dynamic_bound`
 
 **Usage**
-`--dynamic_bound <n>`
+```
+--dynamic_bound <n>
+```
 
 **What does it do?**
 If set to zero (the default), contract creation (via the `new` statement or the `create`/`create2` instructions) will result in a havoc, like any other unresolved external call. If non-zero, then dynamic contract creation will be modeled with cloning, where each contract will be cloned at most n times.
@@ -1257,7 +1281,9 @@ set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_ar
 This option disables the storage splitting optimization.
 
 **Usage**
-`--prover_args '-enableStorageSplitting false'`
+```
+--prover_args '-enableStorageSplitting false'
+```
 
 (-maxnumberofreachchecksbasedondomination)=
 #### `-maxNumberOfReachChecksBasedOnDomination`
@@ -1266,7 +1292,9 @@ This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
 **Usage**
-`--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'`
+```
+--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'
+```
 
 (-optimisticreturnsize)=
 #### `-optimisticReturnsize`
@@ -1283,7 +1311,9 @@ the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
 **Usage**
-`--prover_args '-optimisticReturnsize true'`
+```
+--prover_args '-optimisticReturnsize true'
+```
 
 (-smt_groundquantifiers)=
 #### `-smt_groundQuantifiers`
@@ -1292,7 +1322,9 @@ This option disables quantifier grounding.  See {ref}`grounding` for more
 information.
 
 **Usage**
-`--prover_args '-smt_groundQuantifiers false'`
+```
+--prover_args '-smt_groundQuantifiers false'
+```
 
 (-superoptimisticreturnsize)=
 #### `-superOptimisticReturnsize`
@@ -1303,7 +1335,9 @@ It will set the value returned by the `RETURNSIZE` EVM instruction
 to the size of the output buffer as specified by the summarized `CALL` instruction.
 
 **Usage**
-`--prover_args '-superOptimisticReturnsize true'`
+```
+--prover_args '-superOptimisticReturnsize true'
+```
 
 
 (control-flow-splitting-options)=
@@ -1316,7 +1350,9 @@ See [here](control-flow-splitting) for an explanation of control flow splitting.
 ### `-depth <number>`
 
 **Usage**
-`--prover_args '-depth <number>'`
+```
+--prover_args '-depth <number>'
+```
 
 **What does it do?**
 
@@ -1343,7 +1379,9 @@ certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-depth 5'
 ### `-dontStopAtFirstSplitTimeout`
 
 **Usage**
-`--prover_args '-dontStopAtFirstSplitTimeout <true/false>'`
+```
+--prover_args '-dontStopAtFirstSplitTimeout <true/false>'
+```
 
 **What does it do?**
 
@@ -1374,7 +1412,9 @@ The "medium timeout" determines how much time the SMT solver gets for checking a
 (For split leaves, the full {ref}`--smt_timeout` is used.)
 
 **Usage**
-`--prover_args '-mediumTimeout <seconds>'`
+```
+--prover_args '-mediumTimeout <seconds>'
+```
 
 **What does it do?**
 
@@ -1402,7 +1442,9 @@ With this option, the splitting can be configured to skip the SMT solver-based c
 at low splitting levels, thus generating sub-{term}`split`s up to a given depth immediately.
 
 **Usage**
-`--prover_args '-smt_initialSplitDepth <number>'`
+```
+--prover_args '-smt_initialSplitDepth <number>'
+```
 
 **What does it do?**
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -167,12 +167,16 @@ timeout and will decrease the time to get the final job result for the less comp
 **Example**
 If `Bank.spec` includes the following properties:
 
-`invariant address_zero_cannot_become_an_account()`
-`rule withdraw_succeeds()`
-`rule withdraw_fails()`
+```cvl
+invariant address_zero_cannot_become_an_account()
+rule withdraw_succeeds()
+rule withdraw_fails()
+```
 
 If we want to run the invariant on different Prover jobs we could run
-`certoraRun Bank.sol --verify Bank:Bank.spec --split_rules address_zero_cannot_become_an_account`
+```sh
+certoraRun Bank.sol --verify Bank:Bank.spec --split_rules address_zero_cannot_become_an_account
+```
 
 The rest of the rules (`withdraw_succeeds` and `withdraw_fails`) will run together in a different Prover job.
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -533,6 +533,11 @@ certoraRun Bank.sol Exchange.sol Token.vy --verify Bank:Bank.spec --compiler_map
 (--packages)=
 ## `--packages`
 
+**Usage**
+```sh
+--packages <name>=<path>...
+```
+
 **What does it do?**
 For each package, gets the path to a directory including that Solidity package.
 
@@ -546,6 +551,11 @@ certoraRun Bank.sol --verify Bank:Bank.spec --packages ds-stop=$PWD/lib/ds-token
 
 (--packages_path)=
 ## `--packages_path`
+
+**Usage**
+```sh
+--packages_path <path>
+```
 
 **What does it do?**
 Gets the path to a directory including the Solidity packages.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -69,7 +69,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'
 ```
 
 (--rule)=
-### `--rule`
+## `--rule`
 
 **Usage**
 ```
@@ -114,7 +114,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*
 ```
 
 (--exclude_rule)=
-### `--exclude_rule`
+## `--exclude_rule`
 
 **Usage**
 ```
@@ -178,7 +178,7 @@ any `--exclude_rule` flags.
 ```
 
 (--method)=
-### `--method`
+## `--method`
 
 **Usage**
 ```
@@ -270,7 +270,7 @@ certoraRun Main:Example.sol Underlying:Example.sol --verify Main:Example.spec \
 ```
 
 (--wait-for-results)=
-### `--wait_for_results`
+## `--wait_for_results`
 
 **What does it do?**
 Wait for verification results after sending the verification request.
@@ -294,7 +294,7 @@ Options affecting the type of verification run
 ----------------------------------------------
 
 (--coverage_info)=
-### `--coverage_info`
+## `--coverage_info`
 
 **Usage**
 ```
@@ -333,7 +333,7 @@ When we want to run all foundry fuzz tests in the project with the prover.
 `certoraRun --foundry`
 
 (--independent_satisfy)=
-### `--independent_satisfy`
+## `--independent_satisfy`
 
 **What does it do?**
 The independent satisfy mode checks each {ref}`satisfy statement <satisfy>` independently from all other satisfy statements that occurs in a rule.
@@ -392,7 +392,7 @@ When you have a rule with multiple satisfy statements, and you would like to dem
 `certoraRun Bank.sol --verify Bank:Bank.spec --independent_satisfy`
 
 (--multi_assert_check)=
-### `--multi_assert_check`
+## `--multi_assert_check`
 
 **What does it do?**
 This mode checks each assertion statement that occurs in a rule, separately. The check is done by decomposing each rule into multiple sub-rules, each of which checks one assertion, while it assumes all preceding assertions. In addition, all assertions that originate from the Solidity code (as opposed to those from the specification), are checked together by a designated, single sub-rule.
@@ -450,7 +450,7 @@ may be hot spots for summarization etc.
 `certoraRun --project_sanity`
 
 (--rule_sanity)=
-### `--rule_sanity`
+## `--rule_sanity`
 
 **Usage**
 ```
@@ -467,10 +467,12 @@ We suggest using this option routinely while developing rules.  It is also a
 useful check if you notice rules passing surprisingly quickly or easily.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity basic`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity basic
+```
 
 (--short_output)=
-### `--short_output`
+## `--short_output`
 
 **What does it do?**
 Reduces the verbosity of the tool.
@@ -494,10 +496,12 @@ Compiles every smart contract with a different compiler executable (Solidity ver
 When different contracts have to be compiled for different Solidity versions.
 
 **Example**
-`certoraRun Bank.sol Exchange.sol Token.vy --verify Bank:Bank.spec --compiler_map Bank=solc4.25,Exchange=solc6.7,Token=vyper0.3.10`
+```
+certoraRun Bank.sol Exchange.sol Token.vy --verify Bank:Bank.spec --compiler_map Bank=solc4.25,Exchange=solc6.7,Token=vyper0.3.10
+```
 
 (--packages)=
-### `--packages`
+## `--packages`
 
 **What does it do?**
 For each package, gets the path to a directory including that Solidity package.
@@ -506,10 +510,12 @@ For each package, gets the path to a directory including that Solidity package.
 By default we look for the packages in `$NODE_PATH`. If there are packages are in several different directories, use `--packages`.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --packages ds-stop=$PWD/lib/ds-token/lib/ds-stop/src ds-note=$PWD/lib/ds-token/lib/ds-stop/lib/ds-note/src`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --packages ds-stop=$PWD/lib/ds-token/lib/ds-stop/src ds-note=$PWD/lib/ds-token/lib/ds-stop/lib/ds-note/src
+```
 
 (--packages_path)=
-### `--packages_path`
+## `--packages_path`
 
 **What does it do?**
 Gets the path to a directory including the Solidity packages.
@@ -518,10 +524,12 @@ Gets the path to a directory including the Solidity packages.
 By default, we look for the packages in `$NODE_PATH`. If the packages are in any other directory, you must use `--packages_path`.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --packages_path Solidity/packages`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --packages_path Solidity/packages
+```
 
 (--solc)=
-### `--solc`
+## `--solc`
 
 **Usage**
 ```
@@ -535,10 +543,12 @@ Use this option to provide a path to the Solidity compiler executable file. We c
 Whenever you want to use a Solidity compiler executable with a non-default name. This is usually used when you have several Solidity compiler executable versions you switch between.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1
+```
 
 (--solc_allow_path)=
-### `--solc_allow_path`
+## `--solc_allow_path`
 
 **Usage**
 ```
@@ -553,10 +563,12 @@ See [--allow-path specification](https://docs.soliditylang.org/en/v0.8.16/path-r
 When we want to add an additional location the Solidity compiler to load sources from
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc_allow_path ~/Projects/Bank`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc_allow_path ~/Projects/Bank
+```
 
 (--solc_evm_version)=
-### `--solc_evm_version`
+## `--solc_evm_version`
 
 **Usage**
 ```
@@ -570,10 +582,12 @@ Passes the value of this option  to the solidity compiler's option `--evm-versio
 When we want to select the Solidity compiler EVM version
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version Istanbul`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version Istanbul
+```
 
 (--solc_evm_version_map)=
-### `--solc_evm_version_map`
+## `--solc_evm_version_map`
 
 **Usage**
 ```
@@ -588,10 +602,12 @@ Passes the value of this option as is to the solidity compiler's option `--evm-v
 When different contracts have to be compiled with different Solidity EVM versions.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version_map Bank=prague,Exchange=cancun`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version_map Bank=prague,Exchange=cancun
+```
 
 (--solc_optimize)=
-### `--solc_optimize`
+## `--solc_optimize`
 
 **Usage**
 ```
@@ -606,10 +622,12 @@ When we want to activate in the solidity compiler the opcode-based optimizer for
 number of times the optimizer will be activated (if no value is set, the compiler's default is 200 runs)
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize 300`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize 300
+```
 
 (--solc_optimize_map)=
-### `--solc_optimize_map`
+## `--solc_optimize_map`
 
 **Usage**
 ```
@@ -625,11 +643,13 @@ When we want to activate in the solidity compiler the opcode-based optimizer for
 number of times the optimizer will be activated (if no value is set, the compiler's default is 200 runs)
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize_map Bank=200,Exchange=300`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize_map Bank=200,Exchange=300
+```
 
 
 (--solc_via_ir)=
-### `--solc_via_ir`
+## `--solc_via_ir`
 
 **What does it do?**
 Passes the value of this option  to the solidity compiler's option `--via-ir`.
@@ -638,7 +658,9 @@ Passes the value of this option  to the solidity compiler's option `--via-ir`.
 When we want to enable the IR-based code generator
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --solc_via_ir`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --solc_via_ir
+```
 
 Options regarding source code loops
 -----------------------------------

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -131,12 +131,16 @@ Note that you can specify this flag multiple times to filter out several rules o
 **Example**
 If `Bank.spec` includes the following properties:
 
-`invariant address_zero_cannot_become_an_account()`
-`rule withdraw_succeeds()`
-`rule withdraw_fails()`
+```cvl
+invariant address_zero_cannot_become_an_account()
+rule withdraw_succeeds()
+rule withdraw_fails()
+```
 
 If we want to skip both rules we could run
-`certoraRun Bank.sol --verify Bank:Bank.spec --exclude_rule withdraw*`
+```sh
+certoraRun Bank.sol --verify Bank:Bank.spec --exclude_rule withdraw*
+```
 
 (--split_rules)=
 ## `--split_rules`

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1240,6 +1240,8 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_contract_recursion true
 (--optimistic_fallback)=
 ## `--optimistic_fallback`
 
+**What does it do?**
+
 This option determines whether to optimistically assume unresolved external
 calls with an empty input buffer (length 0) *cannot* make arbitrary changes to all states. It makes changes to how
 {ref}`AUTO summaries <auto-summary>` are executed. By default unresolved external
@@ -1384,6 +1386,7 @@ Shows the version of the local installation of the tool you have.
 
 **When to use it?**
 When you suspect you have an old installation. To install the newest version, use `pip install --upgrade certora-cli`.
+
 **Example**
 
 ```sh

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -404,7 +404,9 @@ rule R2_independent {
 When you have a rule with multiple satisfy statements, and you would like to demonstrate each statement separately.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --independent_satisfy`
+```sh
+certoraRun Bank.sol --verify Bank:Bank.spec --independent_satisfy
+```
 
 (--multi_assert_check)=
 ## `--multi_assert_check`
@@ -439,7 +441,9 @@ When you have a rule with multiple assertions:
 
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --multi_assert_check`
+```sh
+certoraRun Bank.sol --verify Bank:Bank.spec --multi_assert_check
+```
 
 (--project_sanity)=
 ## `--project_sanity`
@@ -454,7 +458,9 @@ directory are collected.
 Alternatively, a list of files can be provided in the `.conf` file and then the
 builtin sanity rule will run on all methods of the specified files.
 
-Note - this option implicitly enables the {ref}`--auto_dispatcher` option.
+```{Note}
+This option implicitly enables the {ref}`--auto_dispatcher` option.
+```
 
 **When to use it?**
 Mostly used as a first step when starting to work on a new project, in order to
@@ -498,13 +504,20 @@ Reduces the verbosity of the tool.
 When we do not care much for the output. It is recommended when running the tool in continuous integration.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --short_output`
+```sh
+certoraRun Bank.sol --verify Bank:Bank.spec --short_output
+```
 
 Options that control the Solidity compiler
 ==========================================
 (--compiler_map)=
 (--solc_map)=
 ## `--compiler_map`
+
+**Usage**
+```sh
+--compiler_map <contract>=<version>,...
+```
 
 **What does it do?**
 Compiles every smart contract with a different compiler executable (Solidity version or Vyper). All used contracts must be listed.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1029,14 +1029,16 @@ One is to decrease the timeout. This is useful for simple rules, that are solved
 The second use is when the solvers can prove the property, they just need more time. Usually, if the rule isn't solved in 600 seconds, it will not be solved in 2,000 either. It is better to concentrate your efforts on simplifying the rule, the source code, add more summaries, or use other time-saving options. The prime causes for an increase of `--smt_timeout` are rules that are solved quickly, but time out when you add a small change, such as a requirement, or changing a strict inequality to a weak inequality.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --smt_timeout 300`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --smt_timeout 300
+```
 
 
 Options to set addresses and link contracts
 -------------------------------------------
 
 (--address)=
-### `--address`
+## `--address`
 
 **What does it do?**
 Sets the address of a contract to a given address.
@@ -1047,10 +1049,12 @@ When we have an external contract with a constant address. By default, the Pytho
 **Example**
 
 If we wish the `Oracle` contract to be at address 12, we use
-`certoraRun Bank.sol Oracle.sol --verify Bank:Bank.spec --address Oracle:12`
+```
+certoraRun Bank.sol Oracle.sol --verify Bank:Bank.spec --address Oracle:12
+```
 
 (--contract_extensions)=
-### `--contract_extensions`
+## `--contract_extensions`
 
 **What does it do?**
 In order to support extendability and upgradeability of smart contracts, the proxy
@@ -1090,7 +1094,7 @@ contract already has such a function and this would cause a conflict).
 
 
 (--contract_recursion_limit)=
-### `--contract_recursion_limit`
+## `--contract_recursion_limit`
 
 **Usage**
 ```
@@ -1135,7 +1139,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 ```
 
 (--link)=
-### `--link`
+## `--link`
 
 **Usage**
 ```
@@ -1153,10 +1157,12 @@ Assume we have the contract `Bank.sol` with the following code snippet:
 `IERC20 public underlyingToken;`
 
 We have a contract `BankToken.sol`, and `underlyingToken` should be its address. To do that, we use:
-`certoraRun Bank.sol BankToken.sol --verify Bank:Bank.spec --link Bank:underlyingToken=BankToken`
+```
+certoraRun Bank.sol BankToken.sol --verify Bank:Bank.spec --link Bank:underlyingToken=BankToken
+```
 
 (--optimistic_contract_recursion)=
-### `--optimistic_contract_recursion`
+## `--optimistic_contract_recursion`
 
 **What does it do?**
 Contract linking can cause recursion (see also {ref}`--contract_recursion_limit`).
@@ -1181,7 +1187,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_contract_recursion true
 
 (-optimisticFallback)=
 (--optimistic_fallback)=
-### `--optimistic_fallback`
+## `--optimistic_fallback`
 
 This option determines whether to optimistically assume unresolved external
 calls with an empty input buffer (length 0) *cannot* make arbitrary changes to all states. It makes changes to how
@@ -1189,8 +1195,13 @@ calls with an empty input buffer (length 0) *cannot* make arbitrary changes to a
 calls with an empty input buffer will {term}`havoc` all the storage state of external contracts. When
 `--optimistic_fallback` is enabled, the call will either execute the fallback function in the specified contract, revert, or execute a transfer. It will not havoc any state.
 
+**Example**
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_fallback
+```
+
 (--struct_link)=
-### `--struct_link`
+## `--struct_link`
 
 **Usage**
 ```
@@ -1216,7 +1227,9 @@ struct TokenPair {
 ```
 
 We have two contracts `BankToken.sol` and `LoanToken.sol`. We want `tokenA` of the `tokenPair` to be `BankToken`, and `tokenB` to be `LoanToken`. Addresses take up only one slot. We assume `tokenPair` is the first field of Bank (so it starts at slot zero). To do that, we use:
-`certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --struct_link Bank:0=BankToken Bank:1=LoanToken`
+```
+certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --struct_link Bank:0=BankToken Bank:1=LoanToken
+```
 
 Options for controlling contract creation
 -----------------------------------------

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -29,7 +29,7 @@ Most frequently used options
 ----------------------------
 
 (--verify)=
-### `--verify`
+## `--verify`
 
 **Usage**
 ```
@@ -44,7 +44,9 @@ When you wish to prove properties on the source code. This is by far the most co
 
 **Example**
 If we have a Solidity file `Bank.sol`, with a contract named `Bank` inside it, and a specification file called `Bank.spec`, the run command would be:
-`certoraRun Bank.sol --verify Bank:Bank.spec`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec
+```
 
 (--msg)=
 ### `--msg`
@@ -62,7 +64,9 @@ Adding a message makes it easier to track several runs on [the Prover Dashboard]
 
 **Example**
 To create the message above, we used
-`certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'
+```
 
 (--rule)=
 ### `--rule`
@@ -94,13 +98,20 @@ If `Bank.spec` includes the following properties:
 `rule withdraw_fails()`
 
 If we want to verify only `withdraw_succeeds`, we run
-`certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw_succeeds`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw_succeeds
+```
 
 If we want to verify both `withdraw_succeeds` and `withdraw_fails`, we run
-`certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw_succeeds withdraw_fails`
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw_succeeds withdraw_fails
+```
 
 Alternatively, to verify both `withdraw_succeeds` and `withdraw_fails`, we could
-simply run `certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*`
+simply run 
+```
+certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*
+```
 
 (--exclude_rule)=
 ### `--exclude_rule`

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -26,7 +26,7 @@ See {ref}`conf-files` for more information.
 ```
 
 Most frequently used options
-----------------------------
+============================
 
 (--verify)=
 ## `--verify`

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -569,6 +569,11 @@ Options regarding source code loops
 (--loop_iter)=
 ### `--loop_iter`
 
+**Usage**
+```
+--loop_iter <n>
+```
+
 **What does it do?**
 Sets the maximal number of loop iterations we verify for. The way the Certora Prover handles loops is by unrolling them - if the loop should be executed three times, it will copy the code inside the loop three times. This option sets the number of unrolls. Be aware that the run time grows exponentially by the number of loop iterations.
 
@@ -592,7 +597,7 @@ This option changes the assertions of the loop unwind condition to requirements 
 When you have loops in your code and are getting a counterexample labeled `loop unwind condition`. In general, you need this flag whenever the number of loop iterations varies. It is usually a necessity if using {ref}`--loop_iter`. Note that `--optimistic_loop` could cause {ref}`vacuous rules <--rule_sanity>`.
 
 **Example**
-```
+```bash
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_loop
 ```
 
@@ -625,7 +630,7 @@ call resolution failures.
 
 **Example**
 
-```
+```bash
 certoraRun Bank.sol --verify Bank:Bank.spec --auto_dispatcher
 ```
 
@@ -654,6 +659,9 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 
 (--nondet_minimal_difficulty)=
 ### `--nondet_minimal_difficulty`
+
+**Usage**
+`--nondet_minimal_difficulty <n>`
 
 **What does it do?**
 This option sets the minimal difficulty threshold for the auto-summarization mode enabled by {ref}`--nondet_difficult_funcs`.
@@ -705,7 +713,7 @@ flag to `true`.
 **Example**
 
 ```
-certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_summary_recursion true
+certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_summary_recursion
 ```
 
 ```{caution}
@@ -715,6 +723,9 @@ _could_ actually happen in the deployed contract, this code-path won't be verifi
 
 (--summary_recursion_limit)=
 ### `--summary_recursion_limit`
+
+**Usage**
+`--summary_recursion_limit <n>`
 
 **What does it do?**
 Summaries can cause recursion (see {ref}`--optimistic_summary_recursion`). This
@@ -774,6 +785,9 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 
 (--hashing_length_bound)=
 ### `--hashing_length_bound`
+
+**Usage**
+`--hashing_length_bound <n>`
 
 **What does it do?**
 
@@ -844,7 +858,7 @@ Avoid using this flag unless absolutely necessary. It is always better to fix sy
 
 
 (--global_timeout)=
-### `--global_timeout <seconds>`
+### `--global_timeout`
 Sets the maximal timeout for the Prover.
 Gets an integer input, which represents seconds.
 
@@ -861,6 +875,8 @@ of each individual rule, while the `--global_timeout` flag constrains the
 processing of the entire job, including static analysis and other
 preprocessing.
 
+**Usage**
+`--global_timeout <seconds>`
 
 **When to use it?**
 When running on just a few rules, or when willing to make faster iterations on specs without waiting too long for the entire set of rules to complete.
@@ -874,7 +890,10 @@ Note that even if in the shorter running time not all rules were processed, a se
 See {ref}`--method`
 
 (--smt_timeout)=
-### `--smt_timeout <seconds>`
+### `--smt_timeout`
+
+**Usage**
+`--smt_timeout <seconds>`
 
 **What does it do?**
 Sets the maximal timeout for all the
@@ -962,6 +981,9 @@ contract already has such a function and this would cause a conflict).
 (--contract_recursion_limit)=
 ### `--contract_recursion_limit`
 
+**Usage**
+`--contract_recursion_limit <n>`
+
 **What does it do?**
 Contract inlining can cause recursion (see {ref}`--optimistic_contract_recursion`). This
 option sets the contract recursion level, which is the number of recursive calls
@@ -1001,6 +1023,9 @@ certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 
 (--link)=
 ### `--link`
+
+**Usage**
+`--struct_link <contract>:<slot>=<address>`
 
 **What does it do?**
 Links a slot in a contract with another contract.
@@ -1052,6 +1077,9 @@ calls with an empty input buffer will {term}`havoc` all the storage state of ext
 (--struct_link)=
 ### `--struct_link`
 
+**Usage**
+`--struct_link <contract>:<slot>=<address>`
+
 **What does it do?**
 Links a slot in a struct with another contract. To do that you must calculate the slot number of the field you wish to replace.
 
@@ -1077,7 +1105,10 @@ Options for controlling contract creation
 -----------------------------------------
 
 (--dynamic_bound)=
-### `--dynamic_bound <n>`
+### `--dynamic_bound`
+
+**Usage**
+`--dynamic_bound <n>`
 
 **What does it do?**
 If set to zero (the default), contract creation (via the `new` statement or the `create`/`create2` instructions) will result in a havoc, like any other unresolved external call. If non-zero, then dynamic contract creation will be modeled with cloning, where each contract will be cloned at most n times.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1086,6 +1086,11 @@ Options to set addresses and link contracts
 (--address)=
 ## `--address`
 
+**Usage**
+```sh
+--address <contract>:<address>
+```
+
 **What does it do?**
 Sets the address of a contract to a given address.
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -90,6 +90,7 @@ specific rule.
 One can either specify a specific rule name, or use pattern matching with a `*`.
 
 Note that you can specify this flag multiple times to filter in several rules or rule patterns.
+
 **Example**
 If `Bank.spec` includes the following properties:
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1481,7 +1481,7 @@ to the size of the output buffer as specified by the summarized `CALL` instructi
 
 (control-flow-splitting-options)=
 Control flow splitting options
-==============================
+------------------------------
 
 See [here](control-flow-splitting) for an explanation of control flow splitting.
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1345,7 +1345,7 @@ Advanced options
 ----------------
 
 (--allow_solidity_calls_in_quantifiers)=
-### `--allow_solidity_calls_in_quantifiers`
+## `--allow_solidity_calls_in_quantifiers`
 
 **What does it do?**
 
@@ -1362,7 +1362,7 @@ Upon instruction from the Certora team.
 error on encountering contract method calls in quantified expression bodies.
 
 (--java_args)=
-### `--java_args`
+## `--java_args`
 
 **What does it do?**
 
@@ -1377,7 +1377,7 @@ Upon instruction from the Certora team.
 `--java_args '"-Dcvt.default.parallelism=2"'` - will set the number of “tasks” that can run in parallel to 2.
 
 (--precise_bitwise_ops)=
-### `--precise_bitwise_ops`
+## `--precise_bitwise_ops`
 
 This option models bitwise operations exactly instead of using the default
 {term}`overapproximation`s. It is useful when the Prover reports a
@@ -1390,7 +1390,7 @@ effectively restricting a `mathint` to a `uint256`. We currently do not have a
 setting or encoding that models precisely both bitwise operations and `mathint`.
 
 (--prover_args)=
-### `--prover_args`
+## `--prover_args`
 
 The `--prover_args` option allows you to provide fine-grained tuning options to the
 Prover.  `--prover_args` receives a string containing Prover-specific options, and will be sent as-is to the Prover.
@@ -1398,28 +1398,28 @@ Prover.  `--prover_args` receives a string containing Prover-specific options, a
 set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_args` value must be quoted.
 
 (-enablestoragesplitting)=
-#### `-enableStorageSplitting`
+### `-enableStorageSplitting`
 
 This option disables the storage splitting optimization.
 
 **Usage**
-```
+```bash
 --prover_args '-enableStorageSplitting false'
 ```
 
 (-maxnumberofreachchecksbasedondomination)=
-#### `-maxNumberOfReachChecksBasedOnDomination`
+### `-maxNumberOfReachChecksBasedOnDomination`
 
 This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
 **Usage**
-```
+```bash
 --prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'
 ```
 
 (-optimisticreturnsize)=
-#### `-optimisticReturnsize`
+### `-optimisticReturnsize`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
@@ -1433,12 +1433,12 @@ the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
 **Usage**
-```
+```bash
 --prover_args '-optimisticReturnsize true'
 ```
 
 (-smt_groundquantifiers)=
-#### `-smt_groundQuantifiers`
+### `-smt_groundQuantifiers`
 
 This option disables quantifier grounding.  See {ref}`grounding` for more
 information.
@@ -1449,7 +1449,7 @@ information.
 ```
 
 (-superoptimisticreturnsize)=
-#### `-superOptimisticReturnsize`
+### `-superOptimisticReturnsize`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
@@ -1457,7 +1457,7 @@ It will set the value returned by the `RETURNSIZE` EVM instruction
 to the size of the output buffer as specified by the summarized `CALL` instruction.
 
 **Usage**
-```
+```bash
 --prover_args '-superOptimisticReturnsize true'
 ```
 
@@ -1472,7 +1472,7 @@ See [here](control-flow-splitting) for an explanation of control flow splitting.
 ### `-depth`
 
 **Usage**
-```
+```sh
 --prover_args '-depth <number>'
 ```
 
@@ -1501,7 +1501,7 @@ certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-depth 5'
 ### `-dontStopAtFirstSplitTimeout`
 
 **Usage**
-```
+```sh
 --prover_args '-dontStopAtFirstSplitTimeout <true/false>'
 ```
 
@@ -1534,7 +1534,7 @@ The "medium timeout" determines how much time the SMT solver gets for checking a
 (For split leaves, the full {ref}`--smt_timeout` is used.)
 
 **Usage**
-```
+```sh
 --prover_args '-mediumTimeout <seconds>'
 ```
 
@@ -1564,7 +1564,7 @@ With this option, the splitting can be configured to skip the SMT solver-based c
 at low splitting levels, thus generating sub-{term}`split`s up to a given depth immediately.
 
 **Usage**
-```
+```sh
 --prover_args '-smt_initialSplitDepth <number>'
 ```
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -666,7 +666,7 @@ Options regarding source code loops
 -----------------------------------
 
 (--loop_iter)=
-### `--loop_iter`
+## `--loop_iter`
 
 **Usage**
 ```
@@ -686,7 +686,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --loop_iter 2
 ```
 
 (--optimistic_loop)=
-### `--optimistic_loop`
+## `--optimistic_loop`
 
 **What does it do?**
 The Certora Prover unrolls loops - if the loop should be executed three times, it will copy the code inside the loop three times. After we finish the loop's iterations, we add an assertion to verify we have actually finished running the loop. For example, in a `while (a < b)` loop, after the loop's unrolling, we add `assert a >= b`. We call this assertion the _loop unwind condition_.
@@ -704,7 +704,7 @@ Options regarding summarization
 -------------------------------
 
 (--auto_dispatcher)=
-### `--auto_dispatcher`
+## `--auto_dispatcher`
 
 **What does it do?**
 In case a call's callee cannot be precomputed but the called method's sighash
@@ -734,7 +734,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --auto_dispatcher
 ```
 
 (--nondet_difficult_funcs)=
-### `--nondet_difficult_funcs`
+## `--nondet_difficult_funcs`
 
 **What does it do?**
 When this option is set, the Prover will auto-summarize
@@ -780,7 +780,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs --nondet_mi
 ```
 
 (--optimistic_summary_recursion)=
-### `--optimistic_summary_recursion`
+## `--optimistic_summary_recursion`
 
 **What does it do?**
 In case there's a call to some Solidity function within a summary, we may end up
@@ -823,7 +823,7 @@ _could_ actually happen in the deployed contract, this code-path won't be verifi
 ```
 
 (--summary_recursion_limit)=
-### `--summary_recursion_limit`
+## `--summary_recursion_limit`
 
 **Usage**
 ```
@@ -860,7 +860,7 @@ Options regarding hashing of unbounded data
 -------------------------------------------
 
 (--optimistic_hashing)=
-### `--optimistic_hashing`
+## `--optimistic_hashing`
 
 **What does it do?**
 
@@ -887,7 +887,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 ```
 
 (--hashing_length_bound)=
-### `--hashing_length_bound`
+## `--hashing_length_bound`
 
 **Usage**
 ```
@@ -921,7 +921,7 @@ Options that help reduce the running time
 -----------------------------------------
 
 (--compilation_steps_only)=
-### `--compilation_steps_only`
+## `--compilation_steps_only`
 
 **What does it do?**
 Exits the program after source code and spec compilation without sending
@@ -941,7 +941,7 @@ Here are a few example scenarios:
 certoraRun Example.sol --verify Example:Example.spec --compilation_steps_only
 ```
 
-### `--disable_local_type_checking`
+## `--disable_local_type_checking`
 
 **What does it do?**
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -31,6 +31,11 @@ Most frequently used options
 (--verify)=
 ### `--verify`
 
+**Usage**
+```
+--verify <contract>:<spec_file>
+```
+
 **What does it do?**
 It runs formal verification of properties specified in a .spec file on a given contract. Each contract must have been declared in the input files or have the same name as the source code file it is in.
 
@@ -42,7 +47,12 @@ If we have a Solidity file `Bank.sol`, with a contract named `Bank` inside it, a
 `certoraRun Bank.sol --verify Bank:Bank.spec`
 
 (--msg)=
-### `--msg <description>`
+### `--msg`
+
+**Usage**
+```
+--msg <description>
+```
 
 **What does it do?**
 Adds a message description to your run, similar to a commit message. This message will appear in the title of the completion email sent to you. Note that you need to wrap your message in quotes if it contains spaces.
@@ -157,7 +167,12 @@ any `--exclude_rule` flags.
 ```
 
 (--method)=
-### `--method <method_signature>`
+### `--method`
+
+**Usage**
+```
+--method <method_signature>...
+```
 
 **What does it do?**
 Only uses functions with the given method signature when instantiating
@@ -212,11 +227,16 @@ Note that many shells will interpret the `(` and `)` characters specially, so
 the method signature argument will usually need to be quoted as in the example.
 
 (--parametric_contracts)=
-### `--parametric_contracts <contract_name> ...`
+### `--parametric_contracts`
 
 ```{versionadded} 5.0
 Prior to version 5, method variables and invariants were only instantiated with
 methods of {ref}`currentContract`.
+```
+
+**Usage**
+```
+--parametric_contracts <contract_name>...
 ```
 
 **What does it do?**
@@ -264,6 +284,11 @@ Options affecting the type of verification run
 
 (--coverage_info)=
 ### `--coverage_info`
+
+**Usage**
+```
+--coverage_info <none|basic|advanced>
+```
 
 **What does it do?**
 This option enables .sol and .spec coverage analysis and visualization.  The `--coverage_info` option may
@@ -416,6 +441,11 @@ may be hot spots for summarization etc.
 (--rule_sanity)=
 ### `--rule_sanity`
 
+**Usage**
+```
+--rule_sanity <none|basic|advanced>
+```
+
 **What does it do?**
 This option enables sanity checking for rules.  The `--rule_sanity` option may
 be followed by one of `none`, `basic`, or `advanced`;
@@ -482,6 +512,11 @@ By default, we look for the packages in `$NODE_PATH`. If the packages are in any
 (--solc)=
 ### `--solc`
 
+**Usage**
+```
+--solc <solc_executable>
+```
+
 **What does it do?**
 Use this option to provide a path to the Solidity compiler executable file. We check in all directories in the `$PATH` environment variable for an executable with this name. If `--solc` is not used, we look for an executable called `solc`, or `solc.exe` on windows platforms.
 
@@ -493,6 +528,11 @@ Whenever you want to use a Solidity compiler executable with a non-default name.
 
 (--solc_allow_path)=
 ### `--solc_allow_path`
+
+**Usage**
+```
+--solc_allow_path <path>
+```
 
 **What does it do?**
 Passes the value of this option as is to the solidity compiler's option `--allow-paths`.
@@ -507,6 +547,11 @@ When we want to add an additional location the Solidity compiler to load sources
 (--solc_evm_version)=
 ### `--solc_evm_version`
 
+**Usage**
+```
+--solc_evm_version <version>
+```
+
 **What does it do?**
 Passes the value of this option  to the solidity compiler's option `--evm-version`.
 
@@ -518,6 +563,11 @@ When we want to select the Solidity compiler EVM version
 
 (--solc_evm_version_map)=
 ### `--solc_evm_version_map`
+
+**Usage**
+```
+--solc_evm_version_map <contract>=<version>,...
+```
 
 **What does it do?**
 Set EVM version values when different files run with different EVM versions
@@ -532,6 +582,11 @@ When different contracts have to be compiled with different Solidity EVM version
 (--solc_optimize)=
 ### `--solc_optimize`
 
+**Usage**
+```
+--solc_optimize <n>
+```
+
 **What does it do?**
 Passes the value of this option as is to the solidity compiler's option `--optimize` and `--optimize-runs`.
 
@@ -544,6 +599,11 @@ number of times the optimizer will be activated (if no value is set, the compile
 
 (--solc_optimize_map)=
 ### `--solc_optimize_map`
+
+**Usage**
+```
+--solc_optimize_map <contract>=<n>,...
+```
 
 **What does it do?**
 Set optimize values when different files run with different number of runs

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1229,10 +1229,15 @@ When you prefer not to add explicit `DISPATCHER` summaries to methods invoked by
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site,
 and `Foo` calls some method `m()` which you wish to automatically link to the newly created contract.
 Note that you must add a `--dynamic_bound` argument as well.
-`certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch true`
+`certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch`
 
 (--prototype)=
-### `--prototype <hex string>=<contract>`
+### `--prototype`
+
+**Usage**
+```
+--prototype <hex string>=<contract>
+```
 
 **What does it do?**
 Instructs the Prover to use a specific contract type for the return value from a call to `create` or `create2` on the given hexadecimal string as a prefix. The hexadecimal string represents proxy code that forwards calls to another contract. As we are using the prototype flag to skip calls to the proxy, no constructor code is being simulated for these contract creation resolutions.
@@ -1407,7 +1412,7 @@ Control flow splitting options
 See [here](control-flow-splitting) for an explanation of control flow splitting.
 
 (-depth)=
-### `-depth <number>`
+### `-depth`
 
 **Usage**
 ```

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -957,9 +957,9 @@ This flag should only be used in rare cases when you believe the local syntax or
 certoraRun MyContract.sol --verify MyContract:MySpec --disable_local_typechecking
 ```
 
-**Note**
-
+```{caution}
 Avoid using this flag unless absolutely necessary. It is always better to fix syntax or type issues locally to ensure a smoother verification process.
+```
 
 
 (--global_timeout)=

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -296,7 +296,7 @@ certoraRun Example.sol --verify Example:Example.spec --wait_for_results
 ```
 
 Options affecting the type of verification run
-----------------------------------------------
+==============================================
 
 (--coverage_info)=
 ## `--coverage_info`
@@ -493,7 +493,7 @@ When we do not care much for the output. It is recommended when running the tool
 `certoraRun Bank.sol --verify Bank:Bank.spec --short_output`
 
 Options that control the Solidity compiler
-------------------------------------------
+==========================================
 (--compiler_map)=
 (--solc_map)=
 ## `--compiler_map`
@@ -672,7 +672,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --solc_via_ir
 ```
 
 Options regarding source code loops
------------------------------------
+===================================
 
 (--loop_iter)=
 ## `--loop_iter`
@@ -710,7 +710,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_loop
 ```
 
 Options regarding summarization
--------------------------------
+===============================
 
 (--auto_dispatcher)=
 ## `--auto_dispatcher`
@@ -866,7 +866,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --summary_recursion_limit 3
 
 
 Options regarding hashing of unbounded data
--------------------------------------------
+===========================================
 
 (--optimistic_hashing)=
 ## `--optimistic_hashing`
@@ -927,7 +927,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --hashing_length_bound 128
 
 
 Options that help reduce the running time
------------------------------------------
+=========================================
 
 (--compilation_steps_only)=
 ## `--compilation_steps_only`
@@ -1044,7 +1044,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --smt_timeout 300
 
 
 Options to set addresses and link contracts
--------------------------------------------
+===========================================
 
 (--address)=
 ## `--address`
@@ -1242,7 +1242,7 @@ certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --struct
 ```
 
 Options for controlling contract creation
------------------------------------------
+=========================================
 
 (--dynamic_bound)=
 ## `--dynamic_bound`
@@ -1332,7 +1332,7 @@ Also note that the hex string must be:
 
 
 Version options
------------------
+===============
 
 (--version)=
 ## `--version`
@@ -1351,7 +1351,7 @@ certoraRun --version
 
 
 Advanced options
-----------------
+================
 
 (--allow_solidity_calls_in_quantifiers)=
 ## `--allow_solidity_calls_in_quantifiers`
@@ -1473,7 +1473,7 @@ to the size of the output buffer as specified by the summarized `CALL` instructi
 
 (control-flow-splitting-options)=
 Control flow splitting options
-------------------------------
+==============================
 
 See [here](control-flow-splitting) for an explanation of control flow splitting.
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -6,12 +6,12 @@ The `certoraRun` utility invokes the Solidity compiler and afterwards sends th
 
 The most commonly used command is:
 
-```bash
+```sh
 certoraRun contractFile:contractName --verify contractName:specFile
 ```
 
 If `contractFile` is named `contractName.sol`, the run command can be simplified to
-```bash
+```sh
 certoraRun contractFile --verify contractName:specFile
 ```
 
@@ -32,7 +32,7 @@ Most frequently used options
 ## `--verify`
 
 **Usage**
-```
+```sh
 --verify <contract>:<spec_file>
 ```
 
@@ -44,7 +44,7 @@ When you wish to prove properties on the source code. This is by far the most co
 
 **Example**
 If we have a Solidity file `Bank.sol`, with a contract named `Bank` inside it, and a specification file called `Bank.spec`, the run command would be:
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec
 ```
 
@@ -52,7 +52,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec
 ## `--msg`
 
 **Usage**
-```
+```sh
 --msg <description>
 ```
 
@@ -64,7 +64,7 @@ Adding a message makes it easier to track several runs on [the Prover Dashboard]
 
 **Example**
 To create the message above, we used
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'
 ```
 
@@ -72,7 +72,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'
 ## `--rule`
 
 **Usage**
-```
+```sh
 --rule <rule_name_pattern>...
 ```
 
@@ -98,18 +98,18 @@ If `Bank.spec` includes the following properties:
 `rule withdraw_fails()`
 
 If we want to verify only `withdraw_succeeds`, we run
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw_succeeds
 ```
 
 If we want to verify both `withdraw_succeeds` and `withdraw_fails`, we run
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw_succeeds withdraw_fails
 ```
 
 Alternatively, to verify both `withdraw_succeeds` and `withdraw_fails`, we could
 simply run 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*
 ```
 
@@ -117,7 +117,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*
 ## `--exclude_rule`
 
 **Usage**
-```
+```sh
 --exclude_rule <rule_name_pattern>...
 ```
 
@@ -141,7 +141,7 @@ If we want to skip both rules we could run
 ## `--split_rules`
 
 **Usage**
-```
+```sh
 --split_rules <rule_name_pattern>...
 ```
 
@@ -181,7 +181,7 @@ any `--exclude_rule` flags.
 ## `--method`
 
 **Usage**
-```
+```sh
 --method <method_signature>...
 ```
 
@@ -246,7 +246,7 @@ methods of {ref}`currentContract`.
 ```
 
 **Usage**
-```
+```sh
 --parametric_contracts <contract_name>...
 ```
 
@@ -297,7 +297,7 @@ Options affecting the type of verification run
 ## `--coverage_info`
 
 **Usage**
-```
+```sh
 --coverage_info <none|basic|advanced>
 ```
 
@@ -457,7 +457,7 @@ certoraRun --project_sanity
 ## `--rule_sanity`
 
 **Usage**
-```
+```sh
 --rule_sanity <none|basic|advanced>
 ```
 
@@ -471,7 +471,7 @@ We suggest using this option routinely while developing rules.  It is also a
 useful check if you notice rules passing surprisingly quickly or easily.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --rule_sanity basic
 ```
 
@@ -514,7 +514,7 @@ For each package, gets the path to a directory including that Solidity package.
 By default we look for the packages in `$NODE_PATH`. If there are packages are in several different directories, use `--packages`.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --packages ds-stop=$PWD/lib/ds-token/lib/ds-stop/src ds-note=$PWD/lib/ds-token/lib/ds-stop/lib/ds-note/src
 ```
 
@@ -528,7 +528,7 @@ Gets the path to a directory including the Solidity packages.
 By default, we look for the packages in `$NODE_PATH`. If the packages are in any other directory, you must use `--packages_path`.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --packages_path Solidity/packages
 ```
 
@@ -536,7 +536,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --packages_path Solidity/packages
 ## `--solc`
 
 **Usage**
-```
+```sh
 --solc <solc_executable>
 ```
 
@@ -547,7 +547,7 @@ Use this option to provide a path to the Solidity compiler executable file. We c
 Whenever you want to use a Solidity compiler executable with a non-default name. This is usually used when you have several Solidity compiler executable versions you switch between.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1
 ```
 
@@ -555,7 +555,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --solc solc8.1
 ## `--solc_allow_path`
 
 **Usage**
-```
+```sh
 --solc_allow_path <path>
 ```
 
@@ -567,7 +567,7 @@ See [--allow-path specification](https://docs.soliditylang.org/en/v0.8.16/path-r
 When we want to add an additional location the Solidity compiler to load sources from
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc_allow_path ~/Projects/Bank
 ```
 
@@ -575,7 +575,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --solc_allow_path ~/Projects/Bank
 ## `--solc_evm_version`
 
 **Usage**
-```
+```sh
 --solc_evm_version <version>
 ```
 
@@ -586,7 +586,7 @@ Passes the value of this option  to the solidity compiler's option `--evm-versio
 When we want to select the Solidity compiler EVM version
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version Istanbul
 ```
 
@@ -594,7 +594,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version Istanbul
 ## `--solc_evm_version_map`
 
 **Usage**
-```
+```sh
 --solc_evm_version_map <contract>=<version>,...
 ```
 
@@ -606,7 +606,7 @@ Passes the value of this option as is to the solidity compiler's option `--evm-v
 When different contracts have to be compiled with different Solidity EVM versions.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version_map Bank=prague,Exchange=cancun
 ```
 
@@ -614,7 +614,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --solc_evm_version_map Bank=prague,E
 ## `--solc_optimize`
 
 **Usage**
-```
+```sh
 --solc_optimize <n>
 ```
 
@@ -626,7 +626,7 @@ When we want to activate in the solidity compiler the opcode-based optimizer for
 number of times the optimizer will be activated (if no value is set, the compiler's default is 200 runs)
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize 300
 ```
 
@@ -634,7 +634,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize 300
 ## `--solc_optimize_map`
 
 **Usage**
-```
+```sh
 --solc_optimize_map <contract>=<n>,...
 ```
 
@@ -647,7 +647,7 @@ When we want to activate in the solidity compiler the opcode-based optimizer for
 number of times the optimizer will be activated (if no value is set, the compiler's default is 200 runs)
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc_optimize_map Bank=200,Exchange=300
 ```
 
@@ -662,7 +662,7 @@ Passes the value of this option  to the solidity compiler's option `--via-ir`.
 When we want to enable the IR-based code generator
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --solc_via_ir
 ```
 
@@ -673,7 +673,7 @@ Options regarding source code loops
 ## `--loop_iter`
 
 **Usage**
-```
+```sh
 --loop_iter <n>
 ```
 
@@ -685,7 +685,7 @@ The default number of loop iterations we unroll is one. However, in many cases, 
 
 **Example**
 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --loop_iter 2
 ```
 
@@ -700,7 +700,7 @@ This option changes the assertions of the loop unwind condition to requirements 
 When you have loops in your code and are getting a counterexample labeled `loop unwind condition`. In general, you need this flag whenever the number of loop iterations varies. It is usually a necessity if using {ref}`--loop_iter`. Note that `--optimistic_loop` could cause {ref}`vacuous rules <--rule_sanity>`.
 
 **Example**
-```bash
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_loop
 ```
 
@@ -733,7 +733,7 @@ call resolution failures.
 
 **Example**
 
-```bash
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --auto_dispatcher
 ```
 
@@ -756,7 +756,7 @@ verification results, as well as highlighting potentially difficult functions.
 
 **Example**
 
-```bash
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 ```
 
@@ -764,7 +764,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 ## `--nondet_minimal_difficulty`
 
 **Usage**
-```
+```sh
 --nondet_minimal_difficulty <n>
 ```
 
@@ -817,7 +817,7 @@ flag to `true`.
 
 **Example**
 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_summary_recursion
 ```
 
@@ -830,7 +830,7 @@ _could_ actually happen in the deployed contract, this code-path won't be verifi
 ## `--summary_recursion_limit`
 
 **Usage**
-```
+```sh
 --summary_recursion_limit <n>
 ```
 
@@ -855,7 +855,7 @@ to `true`.
 
 **Example**
 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --summary_recursion_limit 3
 ```
 
@@ -886,7 +886,7 @@ When the assertion regarding unbounded hashing is thrown, but it is acceptable f
 
 **Example**
 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 ```
 
@@ -894,7 +894,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_hashing
 ## `--hashing_length_bound`
 
 **Usage**
-```
+```sh
 --hashing_length_bound <n>
 ```
 
@@ -916,7 +916,7 @@ Reasons to raise this value:
 
 **Example**
 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --hashing_length_bound 128
 ```
 
@@ -985,7 +985,7 @@ processing of the entire job, including static analysis and other
 preprocessing.
 
 **Usage**
-```
+```sh
 --global_timeout <seconds>
 ```
 
@@ -994,7 +994,7 @@ When running on just a few rules, or when willing to make faster iterations on s
 Note that even if in the shorter running time not all rules were processed, a second run may pull some results from cache, and therefore more results will be available.
 
 **Example**
-```bash
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --global_timeout 60
 ```
 
@@ -1006,7 +1006,7 @@ See {ref}`--method`
 ## `--smt_timeout`
 
 **Usage**
-```shell
+```sh
 --smt_timeout <seconds>
 ```
 
@@ -1033,7 +1033,7 @@ One is to decrease the timeout. This is useful for simple rules, that are solved
 The second use is when the solvers can prove the property, they just need more time. Usually, if the rule isn't solved in 600 seconds, it will not be solved in 2,000 either. It is better to concentrate your efforts on simplifying the rule, the source code, add more summaries, or use other time-saving options. The prime causes for an increase of `--smt_timeout` are rules that are solved quickly, but time out when you add a small change, such as a requirement, or changing a strict inequality to a weak inequality.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --smt_timeout 300
 ```
 
@@ -1053,7 +1053,7 @@ When we have an external contract with a constant address. By default, the Pytho
 **Example**
 
 If we wish the `Oracle` contract to be at address 12, we use
-```
+```sh
 certoraRun Bank.sol Oracle.sol --verify Bank:Bank.spec --address Oracle:12
 ```
 
@@ -1101,7 +1101,7 @@ contract already has such a function and this would cause a conflict).
 ## `--contract_recursion_limit`
 
 **Usage**
-```
+```sh
 --contract_recursion_limit <n>
 ```
 
@@ -1138,7 +1138,7 @@ as the code may in fact allow theoretically unbounded recursion.
 
 **Example**
 
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 ```
 
@@ -1146,7 +1146,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --contract_recursion_limit 3
 ## `--link`
 
 **Usage**
-```
+```sh
 --struct_link <contract>:<slot>=<address>
 ```
 
@@ -1161,7 +1161,7 @@ Assume we have the contract `Bank.sol` with the following code snippet:
 `IERC20 public underlyingToken;`
 
 We have a contract `BankToken.sol`, and `underlyingToken` should be its address. To do that, we use:
-```
+```sh
 certoraRun Bank.sol BankToken.sol --verify Bank:Bank.spec --link Bank:underlyingToken=BankToken
 ```
 
@@ -1185,7 +1185,7 @@ beyond the specified recursion limit ({ref}`--contract_recursion_limit`).
 ```
 
 **Example**
-```
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_contract_recursion true --contract_recursion_limit 1
 ```
 
@@ -1200,7 +1200,7 @@ calls with an empty input buffer will {term}`havoc` all the storage state of ext
 `--optimistic_fallback` is enabled, the call will either execute the fallback function in the specified contract, revert, or execute a transfer. It will not havoc any state.
 
 **Example**
-```bash
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_fallback
 ```
 
@@ -1208,7 +1208,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_fallback
 ## `--struct_link`
 
 **Usage**
-```
+```sh
 --struct_link <contract>:<slot>=<address>
 ```
 
@@ -1232,7 +1232,7 @@ struct TokenPair {
 
 We have two contracts `BankToken.sol` and `LoanToken.sol`. We want `tokenA` of the `tokenPair` to be `BankToken`, and `tokenB` to be `LoanToken`. Addresses take up only one slot. We assume `tokenPair` is the first field of Bank (so it starts at slot zero). To do that, we use:
 
-```bash
+```sh
 certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --struct_link Bank:0=BankToken Bank:1=LoanToken
 ```
 
@@ -1243,7 +1243,7 @@ Options for controlling contract creation
 ## `--dynamic_bound`
 
 **Usage**
-```
+```sh
 --dynamic_bound <n>
 ```
 
@@ -1255,7 +1255,7 @@ When you wish to model contract creation, that is, simulating the actual creatio
 
 **Example**
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site.
-```bash
+```sh
 certoraRun C.sol Foo.sol --dynamic_bound 1
 ```
 
@@ -1284,7 +1284,7 @@ When you prefer not to add explicit `DISPATCHER` summaries to methods invoked by
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site,
 and `Foo` calls some method `m()` which you wish to automatically link to the newly created contract.
 Note that you must add a `--dynamic_bound` argument as well.
-```bash
+```sh
 certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch
 ```
 
@@ -1292,7 +1292,7 @@ certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch
 ## `--prototype`
 
 **Usage**
-```
+```sh
 --prototype <hex string>=<contract>
 ```
 
@@ -1315,7 +1315,7 @@ assembly {
 ```
 Then you can set the string `3d602d80600a3d3981f3363d3d373d3d3d363d73` appearing in the first `mstore` after the `0x` prefix as a "prototype" for `Foo`.
 The Prover will then be able to create a new instance of `Foo` at the point where the code creates it:
-```bash
+```sh
 certoraRun C.sol Foo.sol --prototype 3d602d80600a3d3981f3363d3d373d3d3d363d73=Foo --dynamic_bound 1
 ```
 Note: this argument has no effect if the {ref}`dynamic bound <--dynamic_bound>` is zero.
@@ -1339,7 +1339,7 @@ Shows the version of the local installation of the tool you have.
 When you suspect you have an old installation. To install the newest version, use `pip install --upgrade certora-cli`.
 **Example**
 
-```bash
+```sh
 certoraRun --version
 ```
 
@@ -1407,7 +1407,7 @@ set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_ar
 This option disables the storage splitting optimization.
 
 **Usage**
-```bash
+```sh
 --prover_args '-enableStorageSplitting false'
 ```
 
@@ -1418,7 +1418,7 @@ This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
 **Usage**
-```bash
+```sh
 --prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'
 ```
 
@@ -1437,7 +1437,7 @@ the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
 **Usage**
-```bash
+```sh
 --prover_args '-optimisticReturnsize true'
 ```
 
@@ -1448,7 +1448,7 @@ This option disables quantifier grounding.  See {ref}`grounding` for more
 information.
 
 **Usage**
-```
+```sh
 --prover_args '-smt_groundQuantifiers false'
 ```
 
@@ -1461,7 +1461,7 @@ It will set the value returned by the `RETURNSIZE` EVM instruction
 to the size of the output buffer as specified by the summarized `CALL` instruction.
 
 **Usage**
-```bash
+```sh
 --prover_args '-superOptimisticReturnsize true'
 ```
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -963,7 +963,7 @@ Avoid using this flag unless absolutely necessary. It is always better to fix sy
 
 
 (--global_timeout)=
-### `--global_timeout`
+## `--global_timeout`
 Sets the maximal timeout for the Prover.
 Gets an integer input, which represents seconds.
 
@@ -990,9 +990,11 @@ When running on just a few rules, or when willing to make faster iterations on s
 Note that even if in the shorter running time not all rules were processed, a second run may pull some results from cache, and therefore more results will be available.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --global_timeout 60`
+```console
+certoraRun Bank.sol --verify Bank:Bank.spec --global_timeout 60
+```
 
-### `--method`
+## `--method`
 
 See {ref}`--method`
 
@@ -1000,7 +1002,7 @@ See {ref}`--method`
 ### `--smt_timeout`
 
 **Usage**
-```
+```shell
 --smt_timeout <seconds>
 ```
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -990,7 +990,7 @@ When running on just a few rules, or when willing to make faster iterations on s
 Note that even if in the shorter running time not all rules were processed, a second run may pull some results from cache, and therefore more results will be available.
 
 **Example**
-```console
+```bash
 certoraRun Bank.sol --verify Bank:Bank.spec --global_timeout 60
 ```
 
@@ -999,7 +999,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --global_timeout 60
 See {ref}`--method`
 
 (--smt_timeout)=
-### `--smt_timeout`
+## `--smt_timeout`
 
 **Usage**
 ```shell
@@ -1196,7 +1196,7 @@ calls with an empty input buffer will {term}`havoc` all the storage state of ext
 `--optimistic_fallback` is enabled, the call will either execute the fallback function in the specified contract, revert, or execute a transfer. It will not havoc any state.
 
 **Example**
-```
+```bash
 certoraRun Bank.sol --verify Bank:Bank.spec --optimistic_fallback
 ```
 
@@ -1227,7 +1227,8 @@ struct TokenPair {
 ```
 
 We have two contracts `BankToken.sol` and `LoanToken.sol`. We want `tokenA` of the `tokenPair` to be `BankToken`, and `tokenB` to be `LoanToken`. Addresses take up only one slot. We assume `tokenPair` is the first field of Bank (so it starts at slot zero). To do that, we use:
-```
+
+```bash
 certoraRun Bank.sol BankToken.sol LoanToken.sol --verify Bank:Bank.spec --struct_link Bank:0=BankToken Bank:1=LoanToken
 ```
 
@@ -1235,7 +1236,7 @@ Options for controlling contract creation
 -----------------------------------------
 
 (--dynamic_bound)=
-### `--dynamic_bound`
+## `--dynamic_bound`
 
 **Usage**
 ```
@@ -1250,10 +1251,12 @@ When you wish to model contract creation, that is, simulating the actual creatio
 
 **Example**
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site.
-`certoraRun C.sol Foo.sol --dynamic_bound 1`
+```bash
+certoraRun C.sol Foo.sol --dynamic_bound 1
+```
 
 (--dynamic_dispatch)=
-### `--dynamic_dispatch`
+## `--dynamic_dispatch`
 
 **What does it do?**
 If false (the default), then all contract method invocations on newly created instances will be unresolved. The user must explicitly write {ref}`` `DISPATCHER` <dispatcher>`` summaries for all methods called on newly created instances.
@@ -1277,10 +1280,12 @@ When you prefer not to add explicit `DISPATCHER` summaries to methods invoked by
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site,
 and `Foo` calls some method `m()` which you wish to automatically link to the newly created contract.
 Note that you must add a `--dynamic_bound` argument as well.
-`certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch`
+```bash
+certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch
+```
 
 (--prototype)=
-### `--prototype`
+## `--prototype`
 
 **Usage**
 ```
@@ -1306,7 +1311,9 @@ assembly {
 ```
 Then you can set the string `3d602d80600a3d3981f3363d3d373d3d3d363d73` appearing in the first `mstore` after the `0x` prefix as a "prototype" for `Foo`.
 The Prover will then be able to create a new instance of `Foo` at the point where the code creates it:
-`certoraRun C.sol Foo.sol --prototype 3d602d80600a3d3981f3363d3d373d3d3d363d73=Foo --dynamic_bound 1`
+```bash
+certoraRun C.sol Foo.sol --prototype 3d602d80600a3d3981f3363d3d373d3d3d363d73=Foo --dynamic_bound 1
+```
 Note: this argument has no effect if the {ref}`dynamic bound <--dynamic_bound>` is zero.
 
 Also note that the hex string must be:
@@ -1319,7 +1326,7 @@ Version options
 -----------------
 
 (--version)=
-### `--version`
+## `--version`
 
 **What does it do?**
 Shows the version of the local installation of the tool you have.
@@ -1328,7 +1335,9 @@ Shows the version of the local installation of the tool you have.
 When you suspect you have an old installation. To install the newest version, use `pip install --upgrade certora-cli`.
 **Example**
 
-`certoraRun --version`
+```bash
+certoraRun --version
+```
 
 
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -763,7 +763,7 @@ methods block is that when it's manually written there with `optimistic=true`
 and no such function is found in the scene the Prover will exit with an error,
 but when using the flag it will fall back to the default havoc.
 
-**When to use it**
+**When to use it?**
 When there are many unresolved callee methods, or as a first step to solve
 call resolution failures.
 
@@ -784,7 +784,7 @@ for the Prover.
 
 For more information, see {ref}`detect-candidates-for-summarization`.
 
-**When to use it**
+**When to use it?**
 Using this option is recommended when beginning to work on a large code
 base that includes functions that could be difficult for the Prover.
 It can help the user get faster feedback, both in the form of faster
@@ -807,7 +807,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 **What does it do?**
 This option sets the minimal difficulty threshold for the auto-summarization mode enabled by {ref}`--nondet_difficult_funcs`.
 
-**When to use it**
+**When to use it?**
 If the results of an initial run with {ref}`--nondet_difficult_funcs` were unsatisfactory,
 one can adjust the default threshold to apply the auto-summarization to potentially more or fewer internal functions.
 
@@ -845,7 +845,7 @@ reached (the limit is controlled by the {ref}`--summary_recursion_limit` flag).
 With `--optimistic_summary_recursion`, the Prover will instead assume that the
 limit is never reached.
 
-**When to use it**
+**When to use it?**
 Use this flag when there is recursion due to summaries calling Solidity
 functions, and this causes an undesired assertion failure. In this case one can
 either make the limit larger (via {ref}`--summary_recursion_limit`) or set this
@@ -881,7 +881,7 @@ than the contract recursion limit, the Prover will report an assertion failure (
 will be ignored).
 The default value is zero (i.e. no recursion is allowed).
 
-**When to use it**
+**When to use it?**
 1. Use this option when there is recursion due to summaries calling Solidity
 functions, and this leads to an assertion failure. In this case one can either
 make the limit larger or set (via {ref}`--optimistic_summary_recursion`) flag

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -887,7 +887,10 @@ functions, and this leads to an assertion failure. In this case one can either
 make the limit larger or set (via {ref}`--optimistic_summary_recursion`) flag
 to `true`.
 
-2. Use it if you get the following assertion failure, and disabling {ref}`optimistic fallback <-optimisticFallback>` is not possible: `When inlining a fallback function, found it was already on the stack. Consider disabling optimistic fallback mode.`
+2. Use it if you get the following assertion failure, and disabling {ref}`optimistic fallback <-optimisticFallback>` is not possible: 
+```text
+When inlining a fallback function, found it was already on the stack. Consider disabling optimistic fallback mode.
+```
 
 **Example**
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -319,7 +319,9 @@ See {doc}`../checking/coverage-info` for more information about the analysis.
 We suggest using this option when you have finished (a subset of) your rules and the prover verified them. The analysis tells you which parts of the solidity input are covered by the rules, and also which parts of the rules are actually needed to prove the rules.
 
 **Example**
-`certoraRun Bank.sol --verify Bank:Bank.spec --coverage_info advanced`
+```sh
+certoraRun Bank.sol --verify Bank:Bank.spec --coverage_info advanced
+```
 
 (--foundry)=
 ## `--foundry`
@@ -332,7 +334,9 @@ the {ref}`foundry_integration` on them (specifically, the
 repository if such exists, otherwise over all files in the tree under the
 current working directory.
 
-Note - this option implicitly enables the {ref}`--auto_dispatcher` option.
+```{note}
+This option implicitly enables the {ref}`--auto_dispatcher` option.
+```
 
 
 **When to use it?**

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1007,6 +1007,14 @@ Avoid using this flag unless absolutely necessary. It is always better to fix sy
 
 (--global_timeout)=
 ## `--global_timeout`
+
+**Usage**
+```sh
+--global_timeout <seconds>
+```
+
+**What does it do?**
+
 Sets the maximal timeout for the Prover.
 Gets an integer input, which represents seconds.
 
@@ -1022,11 +1030,6 @@ The global timeout is different from the {ref}`--smt_timeout` option: the
 of each individual rule, while the `--global_timeout` flag constrains the
 processing of the entire job, including static analysis and other
 preprocessing.
-
-**Usage**
-```sh
---global_timeout <seconds>
-```
 
 **When to use it?**
 When running on just a few rules, or when willing to make faster iterations on specs without waiting too long for the entire set of rules to complete.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -55,7 +55,10 @@ To create the message above, we used
 `certoraRun Bank.sol --verify Bank:Bank.spec --msg 'Removed an assertion'`
 
 (--rule)=
-### `--rule <rule_name_pattern> ...`
+### `--rule`
+
+**Usage**
+`--rule <rule_name_pattern>...`
 
 **What does it do?**
 Formally verifies one or more given properties instead of the whole specification file. An invariant can also be selected.
@@ -88,7 +91,10 @@ Alternatively, to verify both `withdraw_succeeds` and `withdraw_fails`, we could
 simply run `certoraRun Bank.sol --verify Bank:Bank.spec --rule withdraw*`
 
 (--exclude_rule)=
-### `--exclude_rule <rule_name_pattern>`
+### `--exclude_rule`
+
+**Usage**
+`--exclude_rule <rule_name_pattern>...`
 
 **What does it do?**
 It is the opposite flag to {ref}`--rule` - use it to specify a list of rules that
@@ -107,7 +113,10 @@ If we want to skip both rules we could run
 `certoraRun Bank.sol --verify Bank:Bank.spec --exclude_rule withdraw*`
 
 (--split_rules)=
-### `--split_rules <rule_name_pattern>`
+### `--split_rules`
+
+**Usage**
+`--split_rules <rule_name_pattern>...`
 
 **What does it do?**
 Typically, all rules (after being filtered by {ref}`--rule` and {ref}`--exclude_rule`) are evaluated in a single Prover job.
@@ -1212,18 +1221,24 @@ Prover.  `--prover_args` receives a string containing Prover-specific options, a
 set by `--smt_timeout` therefore cannot appear in `--prover_args`). `--prover_args` value must be quoted.
 
 (-enablestoragesplitting)=
-#### `--prover_args '-enableStorageSplitting false'`
+#### `-enableStorageSplitting`
 
 This option disables the storage splitting optimization.
 
+**Usage**
+`--prover_args '-enableStorageSplitting false'`
+
 (-maxnumberofreachchecksbasedondomination)=
-#### `--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'`
+#### `-maxNumberOfReachChecksBasedOnDomination`
 
 This option sets the number of program points to test with the `deepSanity`
 built-in rule.  See {ref}`built-in-deep-sanity`.
 
+**Usage**
+`--prover_args '-maxNumberOfReachChecksBasedOnDomination <n>'`
+
 (-optimisticreturnsize)=
-#### `--prover_args '-optimisticReturnsize true'`
+#### `-optimisticReturnsize`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
@@ -1236,19 +1251,28 @@ expected number of return values, then the `RETURNSIZE` value will be set to
 the expected size matching the methods in the scene.
 Otherwise, `RETURNSIZE` will remain non-deterministic.
 
+**Usage**
+`--prover_args '-optimisticReturnsize true'`
+
 (-smt_groundquantifiers)=
-#### `--prover_args '-smt_groundQuantifiers false'`
+#### `-smt_groundQuantifiers`
 
 This option disables quantifier grounding.  See {ref}`grounding` for more
 information.
 
+**Usage**
+`--prover_args '-smt_groundQuantifiers false'`
+
 (-superoptimisticreturnsize)=
-#### `--prover_args '-superOptimisticReturnsize true'`
+#### `-superOptimisticReturnsize`
 
 This option determines whether {ref}`havoc summaries <havoc-summary>` assume
 that the called method returns the correct number of return values.
 It will set the value returned by the `RETURNSIZE` EVM instruction
 to the size of the output buffer as specified by the summarized `CALL` instruction.
+
+**Usage**
+`--prover_args '-superOptimisticReturnsize true'`
 
 
 (control-flow-splitting-options)=
@@ -1258,7 +1282,10 @@ Control flow splitting options
 See [here](control-flow-splitting) for an explanation of control flow splitting.
 
 (-depth)=
-### `--prover_args '-depth <number>'`
+### `-depth <number>`
+
+**Usage**
+`--prover_args '-depth <number>'`
 
 **What does it do?**
 
@@ -1282,7 +1309,10 @@ certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-depth 5'
 ```
 
 (-dontstopatfirstsplittimeout)=
-### `--prover_args '-dontStopAtFirstSplitTimeout <true/false>'`
+### `-dontStopAtFirstSplitTimeout`
+
+**Usage**
+`--prover_args '-dontStopAtFirstSplitTimeout <true/false>'`
 
 **What does it do?**
 
@@ -1306,11 +1336,14 @@ certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-dontStopAtFirstSplit
 ```
 
 (-mediumtimeout)=
-### `--prover_args '-mediumTimeout <seconds>'`
+### `-mediumTimeout`
 
 The "medium timeout" determines how much time the SMT solver gets for checking a
 {term}`split` that is not a {term}`split leaf`.
 (For split leaves, the full {ref}`--smt_timeout` is used.)
+
+**Usage**
+`--prover_args '-mediumTimeout <seconds>'`
 
 **What does it do?**
 
@@ -1332,10 +1365,13 @@ certoraRun Bank.sol --verify Bank:bank.spec --prover_args '-mediumTimeout 20'
 ```
 
 (-smt_initialsplitdepth)=
-### `--prover_args '-smt_initialSplitDepth <number>'`
+### `-smt_initialSplitDepth`
 
 With this option, the splitting can be configured to skip the SMT solver-based checks
 at low splitting levels, thus generating sub-{term}`split`s up to a given depth immediately.
+
+**Usage**
+`--prover_args '-smt_initialSplitDepth <number>'`
 
 **What does it do?**
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -49,7 +49,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec
 ```
 
 (--msg)=
-### `--msg`
+## `--msg`
 
 **Usage**
 ```
@@ -138,7 +138,7 @@ If we want to skip both rules we could run
 `certoraRun Bank.sol --verify Bank:Bank.spec --exclude_rule withdraw*`
 
 (--split_rules)=
-### `--split_rules`
+## `--split_rules`
 
 **Usage**
 ```
@@ -238,7 +238,7 @@ Note that many shells will interpret the `(` and `)` characters specially, so
 the method signature argument will usually need to be quoted as in the example.
 
 (--parametric_contracts)=
-### `--parametric_contracts`
+## `--parametric_contracts`
 
 ```{versionadded} 5.0
 Prior to version 5, method variables and invariants were only instantiated with
@@ -313,7 +313,7 @@ We suggest using this option when you have finished (a subset of) your rules and
 `certoraRun Bank.sol --verify Bank:Bank.spec --coverage_info advanced`
 
 (--foundry)=
-### `--foundry`
+## `--foundry`
 
 **What does it do?**
 Collects all test files in the project (files ending with `.t.sol`), and runs
@@ -330,7 +330,9 @@ Note - this option implicitly enables the {ref}`--auto_dispatcher` option.
 When we want to run all foundry fuzz tests in the project with the prover.
 
 **Example**
-`certoraRun --foundry`
+```sh
+certoraRun --foundry
+```
 
 (--independent_satisfy)=
 ## `--independent_satisfy`
@@ -427,7 +429,7 @@ When you have a rule with multiple assertions:
 `certoraRun Bank.sol --verify Bank:Bank.spec --multi_assert_check`
 
 (--project_sanity)=
-### `--project_sanity`
+## `--project_sanity`
 
 **What does it do?**
 Runs the builtin sanity rule on all methods in the project. If the Prover is run
@@ -447,7 +449,9 @@ Mostly used as a first step when starting to work on a new project, in order to
 may be hot spots for summarization etc.
 
 **Example**
-`certoraRun --project_sanity`
+```sh
+certoraRun --project_sanity
+```
 
 (--rule_sanity)=
 ## `--rule_sanity`
@@ -487,7 +491,7 @@ Options that control the Solidity compiler
 ------------------------------------------
 (--compiler_map)=
 (--solc_map)=
-### `--compiler_map`
+## `--compiler_map`
 
 **What does it do?**
 Compiles every smart contract with a different compiler executable (Solidity version or Vyper). All used contracts must be listed.
@@ -496,7 +500,7 @@ Compiles every smart contract with a different compiler executable (Solidity ver
 When different contracts have to be compiled for different Solidity versions.
 
 **Example**
-```
+```sh
 certoraRun Bank.sol Exchange.sol Token.vy --verify Bank:Bank.spec --compiler_map Bank=solc4.25,Exchange=solc6.7,Token=vyper0.3.10
 ```
 
@@ -757,7 +761,7 @@ certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs
 ```
 
 (--nondet_minimal_difficulty)=
-### `--nondet_minimal_difficulty`
+## `--nondet_minimal_difficulty`
 
 **Usage**
 ```
@@ -775,7 +779,7 @@ The notification in the rule report that contains the applied summaries will pre
 
 **Example**
 
-```bash
+```sh
 certoraRun Bank.sol --verify Bank:Bank.spec --nondet_difficult_funcs --nondet_minimal_difficulty 20
 ```
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1305,7 +1305,7 @@ When you wish to model contract creation, that is, simulating the actual creatio
 **Example**
 Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish to inline the constructor of `Foo` at the creation site.
 ```sh
-certoraRun C.sol Foo.sol --dynamic_bound 1
+certoraRun Bank.sol --verify Bank:Bank.spec --dynamic_bound 1
 ```
 
 (--dynamic_dispatch)=
@@ -1334,7 +1334,7 @@ Suppose a contract `C` creates a new instance of a contract `Foo`, and you wish 
 and `Foo` calls some method `m()` which you wish to automatically link to the newly created contract.
 Note that you must add a `--dynamic_bound` argument as well.
 ```sh
-certoraRun C.sol Foo.sol --dynamic_bound 1 --dynamic_dispatch
+certoraRun Bank.sol --verify Bank:Bank.spec --dynamic_bound 1 --dynamic_dispatch
 ```
 
 (--prototype)=
@@ -1365,7 +1365,7 @@ assembly {
 Then you can set the string `3d602d80600a3d3981f3363d3d373d3d3d363d73` appearing in the first `mstore` after the `0x` prefix as a "prototype" for `Foo`.
 The Prover will then be able to create a new instance of `Foo` at the point where the code creates it:
 ```sh
-certoraRun C.sol Foo.sol --prototype 3d602d80600a3d3981f3363d3d373d3d3d363d73=Foo --dynamic_bound 1
+certoraRun Bank.sol --verify Bank:Bank.spec --prototype 3d602d80600a3d3981f3363d3d373d3d3d363d73=Foo --dynamic_bound 1
 ```
 Note: this argument has no effect if the {ref}`dynamic bound <--dynamic_bound>` is zero.
 


### PR DESCRIPTION
Cleans up option titles to just be the flag name for nicer looking internal documentation links. Usage appears in separate lines.

