### PR TITLE
release notes for v7.26.0

### DIFF
--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -4,6 +4,16 @@ Prover Release Notes
 
 ```{contents}
 ```
+
+7.26.0 (Mar 13, 2025)
+----------------------
+### Rule Report
+- [feat] The Live Statistics panel now supports difficulty information for internal function calls, expanding on the existing support for external and public functions.
+- [feat] Jump-To-Source (JTS) is now available for Rust (CVLR) external calls and `cvlr_satisfy`.
+
+### CVL
+- [feat] Introduced the `executingContract` keyword, which can be used in the methods block. It refers to `address(this)` at the call site where the CVL summary is applied,
+
 7.25.2 (Feb 19, 2025)
 ----------------------
 ### CVL

--- a/docs/user-guide/out-of-resources/timeout.md
+++ b/docs/user-guide/out-of-resources/timeout.md
@@ -411,10 +411,17 @@ Nonlinear integer arithmetic is often the hardest part of the formulas that the
 Certora Prover is solving. 
 
 The Certora Prover displays the absolute number of nonlinear operations, as well
-as their number per external call, in the Live Statistics panel. In the per-call
+as their number per call, in the Live Statistics panel. In the per-call
 display, there is a warning-sign next to the call when there is a non-trivial
 number of nonlinear operations in the call or its sub-call. Currently,
 everything above and including two nonlinear operations is marked in this way.
+
+Unless the detection of internal functions fails, both internal and external calls 
+are taken into account in the statistics. If the detection fails (which should be 
+rare), internal calls are treated as inlined into the external calls. In that 
+case, each inlined internal call's statistics contribute to the statistics of the 
+enclosing external call.
+
 
 ```{figure} nonlinear-ops-field.png
 :name: nonlinear ops field


### PR DESCRIPTION
Link to generated documentation: https://certora-certora-prover-documentation--368.com.readthedocs.build/en/368/docs/prover/changelog/prover_changelog.html#mar-13-2025

