### PR TITLE
Uri/remove allow solidity calls in quantifiers

### DIFF
--- a/docs/cvl/v5-changes.md
+++ b/docs/cvl/v5-changes.md
@@ -253,11 +253,6 @@ hook Sstore i uint256 v {
 Finally, replace `getI` in the `require` statement in rule `there_exists` with the
 ghost variable `gI`: `require (exists uint i . i == gI)`.
 
-If you must use contract method calls in quantified expressions,
-you can still access the old behavior by specifying the
-{ref}`--allow_solidity_calls_in_quantifiers` argument to `certoraRun` on the 
-command line.
-
 
 Method variable restrictions
 ----------------------------

--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -12,7 +12,7 @@ Prover Release Notes
 - [feat] Jump-To-Source (JTS) is now available for Rust (CVLR) external calls and `cvlr_satisfy`.
 
 ### CVL
-- [feat] Introduced the `executingContract` keyword, which can be used in the methods block. It refers to `address(this)` at the call site where the CVL summary is applied,
+- [feat] Introduced the `executingContract` keyword, which can be used in the methods block. It refers to `address(this)` at the call site where the CVL summary is applied.
 
 7.25.2 (Feb 19, 2025)
 ----------------------

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1448,23 +1448,6 @@ certoraRun --version
 Advanced options
 ================
 
-(--allow_solidity_calls_in_quantifiers)=
-## `--allow_solidity_calls_in_quantifiers`
-
-**What does it do?**
-
-Instructs the Prover to permit contract method calls in quantified expression
-bodies.
-
-**When to use it?**
-
-Upon instruction from the Certora team.
-
-**Example**
-
-`--allow_solidity_calls_in_quantifiers` instructs the Prover to not generate an
-error on encountering contract method calls in quantified expression bodies.
-
 (--java_args)=
 ## `--java_args`
 


### PR DESCRIPTION
Removing documentation of `--allow_solidity_calls_in_quantifiers`
Link to generated documentation: https://certora-certora-prover-documentation--371.com.readthedocs.build/en/371/

