### PR TITLE
Remove static_assert and static_require as they are no longer supported

### DIFF
--- a/docs/cvl/statements.md
+++ b/docs/cvl/statements.md
@@ -22,9 +22,7 @@ block ::= statement { statement }
 statement ::= type id [ "=" expr ] ";"
 
             | "require" expr ";"
-            | "static_require" expr ";"
             | "assert" expr [ "," string ] ";"
-            | "static_assert" expr [ "," string ] ";"
             | "satisfy" expr [ "," string ] ";"
 
             | "requireInvariant" id "(" exprs ")" ";"


### PR DESCRIPTION
Jira ticket: TODO
Link to generated documentation: https://certora-certora-prover-documentation--382.com.readthedocs.build/en/382/

