### PR TITLE
removing unsupported/now hidden flags from cvl conversion guide from …

### DIFF
--- a/docs/cvl/cvl2/changes.md
+++ b/docs/cvl/cvl2/changes.md
@@ -836,10 +836,6 @@ This is the list of the flags that were renamed:
 | `--path`         | `--solc_allow_path`   |
 | `--optimize`     | `--solc_optimize`     |
 | `--optimize_map` | `--solc_optimize_map` |
-| `--get_conf`     | `--conf_output_file`  |
-| `--assert`       | `--assert_contracts`  |
-| `--bytecode`     | `--bytecode_jsons`    |
-| `--toolOutput`   | `--tool_output`       |
 | `--structLink`   | `--struct_link`       |              
 | `--javaArgs`     | `--java_args`         |              
 

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1142,7 +1142,8 @@ certoraRun Bank.sol Oracle.sol --verify Bank:Bank.spec --address Oracle:12
 **What does it do?**
 In order to support extendability and upgradeability of smart contracts, the proxy
 pattern is used. In this patterns there is a base contract (the proxy) which delegate-calls
-into "extension" contracts (see e.g. https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies
+into "extension" contracts (read this 
+[explanation](https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies) 
 for more details).
 This flag allows specifying that some contract is actually an extension of another one, to help the Prover
 analyze low-level calls and resolve them correctly in this case.

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -359,7 +359,7 @@ This option implicitly enables the {ref}`--auto_dispatcher` option.
 
 
 **When to use it?**
-When we want to run all foundry fuzz tests in the project with the prover.
+When we want to run all Foundry fuzz tests in the project with the Prover.
 
 **Example**
 ```sh


### PR DESCRIPTION
Removing unsupported or hidden flags mentioned in the doc to convert CVL1 to CVL2.
Also adding docs for flags with a help message that shouldn't be hidden.

Link to generated documentation: https://certora-certora-prover-documentation--384.com.readthedocs.build/en/384/

