### PR TITLE
moving the example of --prover_version to its correct option instead …

### DIFF
--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -1624,6 +1624,13 @@ This option lets you select a specific version of the Certora Prover by providin
 **When to use it?**
 Use this flag to reproduce behavior from an earlier version of the Prover, which is especially useful when features have been changed or deprecated in newer releases. The most common use case is specifying one of the release branches (e.g., release/10April2025) to match the behavior of a known version.
 
+**Example**
+To run verification using the Prover version from the April 10, 2025 release:
+
+```sh
+certoraRun MyContract.sol --verify MyContract:MySpec.spec --prover_version release/10April2025
+```
+
 
 Conf file options
 =================
@@ -1651,13 +1658,6 @@ line or other configuration files.
 
 ```sh
 certoraRun proj.conf --override_base_config confs/base_settings.conf
-```
-
-**Example**
-To run verification using the Prover version from the April 10, 2025 release:
-
-```sh
-certoraRun MyContract.sol --verify MyContract:MySpec.spec --prover_version release/10April2025
 ```
 
 Advanced options


### PR DESCRIPTION
…of to --override_base_config

Naming convention:
 - PRs for features that are in design should have the "proposal" label
 - PRs for features that haven't landed yet should have the "future" label
 - PRs for upcoming releases should have the "release" label
 - PRs with new documentation for existing features should have the "existing feature" label

Before requesting review:
 - Make sure there is a ticket in the DOC board in Jira
 - Make sure CI is passing
   - Spell check failure may require adding backticks around code or updating `spelling_wordlist.txt`
   - See `README.md` for information about style and markdown syntax
   - If the CI Details link gives a 404, you need to log in to readthedocs.com
 - Add link to generated documentation here
   - you can find this by following the read the docs link from the CI check
 - Ask for help in #documentation

Jira ticket: TODO
Link to generated documentation: TODO

