### PR TITLE
changelog version 7.29.0 -> 7.29.1

### DIFF
--- a/docs/prover/changelog/prover_changelog.md
+++ b/docs/prover/changelog/prover_changelog.md
@@ -5,7 +5,7 @@ Prover Release Notes
 ```{contents}
 ```
 
-7.29.0 (May 18, 2025)
+7.29.1 (May 18, 2025)
 ----------------------
 ### CVL
 - [feat] `require` statements now support an optional string reason argument: `require(condition, "reason")`.


### PR DESCRIPTION
The released version is 7.29.1 and not 7.29.0. Updating the changelog accordingly.
