### PR TITLE
Uri/small glossary fixes

### DIFF
--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -178,7 +178,7 @@ quantified expression
   details about quantifiers in CVL.
 
 receiveOrFallback
-  A special function automatically added to every contract to model how Solidity handles calls that either have no calldata or do not match any existing function signature.
+  A special function automatically added to every contract to model how Solidity handles calls that either have no `calldata` or do not match any existing function signature.
   1. If the call has no data and a `receive` function is present, `receive` is invoked.
   2. Otherwise, the `fallback` function is called.
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -242,11 +242,10 @@ SMT solver
 
 sound
 unsound
-  Soundness means that any rule violations in the code being verified are
-  guaranteed to be reported by the Certora Prover.  Unsound approximations
-  such as loop unrolling or certain kinds of harnessing may cause real bugs
-  to be missed by the Prover, and should therefore be used with caution. See
-  {doc}`/docs/prover/approx/index` for more details.
+  Soundness means that the Certora Prover is guaranteed to report any rule violations in the code being verified. 
+  Unsound approximations, such as loop unrolling or certain kinds of harnessing, 
+  may cause the Prover to miss real bugs, and should, therefore, be used with caution. 
+  See {doc}`/docs/prover/approx/index` for more details.
 
 split
 split leaf

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -178,11 +178,14 @@ quantified expression
   details about quantifiers in CVL.
 
 receiveOrFallback
-  A special function we introduce in every contract to model the behavior of Solidity
-  for calls with no data or that do not resolve to any contract function.
-  It will call the receive function if present for calls with no data, and otherwise the fallback function.
-  Shows up in the parametric rules or invariants, as well as in the call trace for such calls, written `<receiveOrFallback>()`.
-  See also [Solidity Documentation](https://docs.soliditylang.org/en/latest/contracts.html#fallback-function).
+  A special function automatically added to every contract to model how Solidity handles calls that either have no calldata or do not match any existing function signature.
+  1. If the call has no data and a `receive` function is present, `receive` is invoked.
+  2. Otherwise, the `fallback` function is called.
+
+  This behavior is modeled in CVL using the synthetic function `receiveOrFallback`, 
+  which may appear in parametric rules, invariants, or call traces as `<receiveOrFallback>()`.
+
+  For more details, see the [Solidity Documentation](https://docs.soliditylang.org/en/latest/contracts.html#fallback-function) on fallback functions.
 
 rule name pattern
   Rule names, like all CVL identifiers, have the same format as Solidity identifiers: 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -143,30 +143,25 @@ underapproximation
 
 optimistic assumptions
 pessimistic assertions
-  Some input programs contain constructs that the Prover can only handle in
-  an approximative way. This approximation entails that the Prover will
-  disregard some specific parts of the programs behavior, like for example the
-  behavior induced by a loop being unrolled beyond a fixed number of times.
-  For each of these constructs the Prover provides a flag controlling whether
-  it should handle them optimistically or pessimistically. (See the links at the
-  end of this paragraph for examples of "optimistic" flags.)
+  Some input programs include constructs that the Prover cannot handle precisely and must instead approximate. 
+  This means the Prover may ignore certain behaviors of the program; 
+  for example, what happens when a loop executes more times than a fixed unrolling limit.
 
-  In pessimistic mode (which is the default) _pessimistic assertions_ are
-  inserted into the program that check whether there is any behavior that needs
-  to be approximated, for instance whether loops are present with bounds
-  exceeding {ref}`--loop_iter`. If this is the case, the rule will fail with
-  a corresponding message.
+  The Prover provides options that let you choose between 
+  pessimistic and optimistic handling for each such approximation. (See the end of this section for examples.)
 
-  In optimistic mode, instead of the assertions, _optimistic assumptions_ are
-  introduced in each of the places where an approximation happens. Each assumption
-  excludes the relevant behavior from checking for one occurrence of the problematic
-  construct, e.g., for each loop.
+  In pessimistic mode (the default), the Prover inserts pessimistic assertions 
+  that check whether the program includes behavior that requires approximation, 
+  such as a loop exceeding the bound set by {ref}`--loop_iter`. 
+  If such behavior is detected, the rule fails with an explanatory message.
 
-  For a list of all "optimistic" settings see {ref}`prover-cli-options`.
-  Examples include {ref}`--optimistic_hashing`, {ref}`--optimistic_loop`,
-  {ref}`--optimistic_summary_recursion`, and more. Also see
-  {ref}`prover-approximations` for more background on some of the
-  approximations.
+  In optimistic mode, the Prover instead inserts optimistic assumptions 
+  at each point where approximation would occur. 
+  These assumptions explicitly exclude the relevant behavior from verification, for example, assuming that no loop exceeds the iteration bound.
+
+  For a list of all available optimistic options, see {ref}`prover-cli-options`. 
+  Examples include {ref}`--optimistic_hashing`, {ref}`--optimistic_loop`, and
+  {ref}`--optimistic_summary_recursion`. For more background on these approximations, refer to {ref}`prover-approximations`.
 
 
 parametric rule

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -238,7 +238,7 @@ SMT solver
   When a formula is satisfiable, the solver may also return a {term}`model`: an assignment of values to variables that makes the formula evaluate to `true`.
   For instance, given the formula `x > 5 ∧ x = y * y`, the solver might return `x = 9, y = 3` as a valid model.
 
-  For more background, see Wikipedia](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories).
+  For more background, see [Wikipedia](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories).
 
 sound
 unsound

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -6,7 +6,6 @@ Glossary
 
 axiom
   A statement accepted as true without proof.
-  [Wikipedia](https://en.wikipedia.org/wiki/Axiom)
 
 call trace
   A call trace is the Prover's visualization of either a
@@ -42,7 +41,7 @@ control flow path
   The Certora Prover's [TAC reports](tac-reports) contain a control flow graph
   of the {term}`TAC` intermediate representation of each given CVL rule.
   The control flow paths are the paths from source to sink in a given CFG.
-  In general (and in practice) the number of control flow paths grows
+  In general (and in practice), the number of control flow paths grows
   exponentially with the size of the CFG. This is known as the path explosion
   problem.
   Further reading:
@@ -62,11 +61,10 @@ EVM
 Ethereum Virtual Machine
 EVM bytecode
   EVM is short for Ethereum Virtual Machine.
-  EVM bytecode is one of the source languages that the Certora Prover internally
-  can take as input for verification. It is produced by the Solidity and Vyper
-  compilers, among others.
-  For details on what the EVM is and how it works, the following links provide
-  good entry points.
+  EVM bytecode is one of the source languages the Certora Prover
+  can take as input for verification. 
+  It is produced by the Solidity and Vyper compilers, among others.
+  The following links provide good entry points for details on what the EVM is and how it works:
   [Official documentation](https://ethereum.org/en/developers/docs/evm/),
   [Wikipedia](https://en.wikipedia.org/wiki/Ethereum#Virtual_machine)
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -261,10 +261,11 @@ summarize
 summarization
 Summaries
   A method summary is a user-provided approximation of the behavior of a
-  contract method.  Summaries are useful if the implementation of a method is
+  contract method.  
+  Summaries are useful if the implementation of a method is
   not available or if the implementation is too complex for the Certora
-  Prover to analyze without timing out.  See {doc}`/docs/cvl/methods` for
-  complete information on different types of method summaries.
+  Prover to analyze without timing out.  
+  See {ref}`summaries` for complete information on different types of method summaries.
 
 
 TAC

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -77,14 +77,14 @@ EVM storage
   [Official documentation](https://ethereum.org/en/developers/docs/smart-contracts/anatomy)
 
 havoc
-  Havoc means that variables are assigned values chosen non-deterministically.
-  A havoc happens in two cases: the first, at the beginning of the rule all variables
-  "havoced". The second, during certain events when the Certora Prover
-  should assume that some variables can change in an unknown way.
-  For example, an external function on an unknown contract
-  may have an arbitrary effect on the state of a third contract.  In this case,
-  we also say that the variable was "havoced".  See {ref}`havoc-summary` and
-  {ref}`havoc-stmt` for more details.
+  Havoc refers to assigning variables arbitrary, non-deterministic values. 
+  This occurs in two main cases:
+  1. At the beginning of a rule, all variables are havoced to model an unknown initial state.
+  2. During rule execution, certain events may cause specific variables to be havoced.
+    For example, when calling an external function on an unknown contract, 
+    the Prover assumes it could arbitrarily affect the state of a third contract.
+  In both cases, we say that the variable was havoced.
+  For more information, see {ref}`havoc-summary` and {ref}`havoc-stmt`.
 
 hyperproperty
   A hyperproperty describes a relationship between two hypothetical sequences

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -220,7 +220,7 @@ UNSAT result
   See also {ref}`rule-overview`.
 
 scene
-  The *scene* refers to the set of contract instances that the Certora Prover
+  The set of contract instances that the Certora Prover
   knows about.
 
 SMT

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -108,7 +108,7 @@ witness example
 
   See {ref}`rule-overview` for more on how these are used.
 
-  In the context of SMT solvers, a model refers to a valuation of the logical constants and uninterpreted functions in the input formula that makes the formula evaluate to `true`. 
+  In the context of SMT solvers, a _model_ refers to a valuation of the logical constants and uninterpreted functions in the input formula that makes the formula evaluate to `true`. 
   See {term}`SAT result` for more details.
 
 linear arithmetic

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -5,7 +5,7 @@ Glossary
 ````{glossary}
 
 axiom
-  a statement accepted as true without proof.
+  A statement accepted as true without proof.
 
 call trace
   A call trace is the Prover's visualization of either a
@@ -51,7 +51,7 @@ control flow path
   % TODO: ok to mention TAC here?
 
 environment
-  The environment of a method call refers to the global variables that solidity
+  The environment of a method call refers to the global variables that Solidity
   provides, including `msg`, `block`, and `tx`.  CVL represents these variables
   in a structure of type {ref}`env <env>`.  The environment does *not* include
   the contract state or the state of other contracts --- these are referred to

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -272,10 +272,12 @@ TAC
   TAC (originally short for "three address code") is an intermediate
   representation
   ([Wikipedia](https://en.wikipedia.org/wiki/Intermediate_representation))
-  used by the Certora Prover. TAC code is kept invisible to the
-  user most of the time, so its details are not in the scope of this
-  documentation. We provide a working understanding, which is helpful for some
-  advanced proving tasks, in the {ref}`tac-reports` section.
+  used by the Certora Prover. 
+  TAC code is kept invisible to the user most of the time, 
+  so its details are not included in the scope of this
+  documentation. 
+  In the {ref}`tac-reports` section We provide a working understanding, 
+  which is helpful for some advanced proving tasks.
 
 tautology
   A tautology is a logical statement that is always true.

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -226,19 +226,19 @@ scene
 
 SMT
 SMT solver
-  "SMT" is short for "Satisfiability Modulo Theories". An SMT solver takes as
-  input a formula in predicate logic and returns whether the formula is
-  satisfiable (short "SAT") or unsatisfiable (short: "UNSAT"). The "Modulo
-  Theory" part means that the solver assumes a meaning for certain symbols in
-  the formula. For instance the theory of integer arithmetic stipulates that the
-  symbols `+`, `-`, `*`, etc. have their regular everyday mathematical
-  meaning.
-  When the formula is satisfiable, the SMT solver can also return a model for
-  the formula. I.e. an assignment of the formula's variables that makes the
-  formula evaluate to "true". For instance, on the formula "x > 5 /\ x = y * y",
-  a solver will return SAT, and produce any valuation where x is the square of
-  an integer and larger than 5, and y is the root of x.
-  Further reading: [Wikipedia](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories)
+  SMT stands for Satisfiability Modulo Theories. 
+  An SMT solver takes as input a formula written in predicate logic and determines 
+  whether it is satisfiable ({term}`SAT`) or unsatisfiable ({term}`UNSAT`).
+
+  The “Modulo Theories” part refers to the solver’s ability to reason about specific background theories,
+  such as integer arithmetic, arrays, or bitvectors. 
+  For example, under the theory of integer arithmetic, 
+  symbols like `+`, `-`, and `*` are interpreted according to their standard mathematical meaning.
+
+  When a formula is satisfiable, the solver may also return a {term}`model`: an assignment of values to variables that makes the formula evaluate to `true`.
+  For instance, given the formula `x > 5 ∧ x = y * y`, the solver might return `x = 9, y = 3` as a valid model.
+
+  For more background, see Wikipedia](https://en.wikipedia.org/wiki/Satisfiability_modulo_theories).
 
 sound
 unsound

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -206,18 +206,19 @@ SAT
 UNSAT
 SAT result
 UNSAT result
-  *SAT* and *UNSAT* are the results that an {term}`SMT solver` returns on a
-  successful run (i.e. not a timeout). SAT means that the input formula is
-  satisfiable and a {term}`model` has been found. UNSAT means that the input
-  formula is unsatisfiable (and thus there is no model for it).
-  Within the Certora Prover, what SAT means depends on the type of rule
-  being checked: For an `assert` rule, SAT means the rule is violated and the
-  SMT model corresponds to a counterexample.
-  For a `satisfy` rule, SAT means the rule is not violated and the SMT model
-  corresponds to a witness example.
-  Conversely, UNSAT means that an `assert` is never violated or a `satisfy` never
-  fulfilled respectively.
-  See also {ref}`rule-overview`.
+  `SAT` and `UNSAT` are the two possible results returned by an {term}`SMT solver` if it does not time out.
+  - `SAT` (satisfiable) means that the input formula can be satisfied, and a corresponding {term}`model` has been found.
+  - `UNSAT` (unsatisfiable) means that no such {term}`model` exists, as the formula cannot be satisfied.
+
+  In the context of the Certora Prover, the interpretation of `SAT` depends on the type of rule being checked:
+  - For an `assert` rule, `SAT` means the rule is violated; the {term}`model` returned serves as a counterexample.
+  - For a `satisfy` rule, `SAT` means the rule is fulfilled; the {term}`model` is a witness example.
+
+  Conversely, `UNSAT` indicates:
+  - An `assert` rule is never violated.
+  - A `satisfy` rule is never fulfilled.
+
+  See also the {ref}`rule-overview` for more background.
 
 scene
   The set of contract instances that the Certora Prover

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -6,18 +6,19 @@ Glossary
 
 axiom
   A statement accepted as true without proof.
+  [Wikipedia](https://en.wikipedia.org/wiki/Axiom)
 
 call trace
   A call trace is the Prover's visualization of either a
   {term}`counterexample` or a {term}`witness example`.
 
-  A call trace illustrates a rule execution that leads up to the violation
+  A call trace illustrates a rule execution that leads to the violation
   of an `assert` statement or the fulfillment of a `satisfy` statement. The
   trace is a sequence of commands in the rule (or in the contracts the rule
   was calling into), starting at the beginning of the rule and ending with the
   violated `assert` or fulfilled `satisfy` statement.
-  In addition to the commands, the call trace also does a best effort at
-  showing information about the program state at each point in the execution.
+  In addition to the commands, the call trace also makes the best effort to
+  show information about the program state at each point in the execution.
   It contains information about the state of global variables at crucial points
   as well as the values of call parameters, return values, and more.
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -114,7 +114,7 @@ witness example
 linear arithmetic
 nonlinear arithmetic
   An arithmetic expression is called linear if it consists only of additions,
-  subtractions, and multiplications by constant. Division and modulo where the
+  subtractions, and multiplications by constants. Division and modulo where the
   second parameter is a constant are also linear arithmetic.
   Examples for linear expressions are `x * 3`, `x / 3`, `5 * (x + 3 * y)`.
   Every arithmetic expression that is not linear is nonlinear.
@@ -123,21 +123,21 @@ nonlinear arithmetic
 
 overapproximation
 underapproximation
-  Sometimes it is useful to replace a complex piece of code with something
-  simpler that is easier to reason about.  If the approximation includes all of
-  the possible behaviors of the original code (and possibly others), it is
-  called an "overapproximation"; if it does not then it is called an
-  "underapproximation".
+  Sometimes, it is useful to replace a complex piece of code with something
+  simpler that is easier to reason about.
+  If the approximation includes all of the possible behaviors of the original code (and possibly others), it is called an "overapproximation"; 
+  if it does not, it is called an "underapproximation".
 
   Example: A {ref}`NONDET <view-summary>` summary is
-  an overapproximation because every possible value that the original
-  implementation could return is considered by the Certora Prover, while an
-  {ref}`ALWAYS <view-summary>` summary is an underapproximation if the
+  an overapproximation because the Certora Prover considers every possible value 
+  that the original implementation could return, 
+  while an {ref}`ALWAYS <view-summary>` summary is an underapproximation if the
   summarized method could return more than one value.
 
-  Proofs on overapproximated programs are {term}`sound`, but there may be
-  spurious {term}`counterexample`s caused by behavior that the original code
-  did not exhibit.  Underapproximations are more dangerous because a property
+  Proofs on overapproximated programs are {term}`sound`, but
+  spurious {term}`counterexample`s may be caused by behavior that the original code
+  did not exhibit. 
+  Underapproximations are more dangerous because a property
   that is successfully verified on the underapproximation may not hold on the
   approximated code.
 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -295,15 +295,13 @@ vacuity
   The {doc}`../prover/checking/sanity` help detect vacuous rules.
 
 verification condition
-  The Certora Prover works by translating a program an a specification into
-  a single logical formula that is satisfiable if and only if the program
-  violates the specification. This formula is called a
-  *verification condition*.
+  The Certora Prover translates a program and a specification into a single logical formula 
+  that is satisfiable if and only if the program violates the specification. 
+  This formula is called a *verification condition*.
   Usually, a run of the Certora Prover generates many verification conditions.
-  For instance a verification condition is generated for every
-  {term}`parametric rule`, and also for each of the sanity checks triggered by
-  {ref}`--rule_sanity`.
-  See also {ref}`white-paper`, {ref}`user-guide`.
+  For instance, the Prover generates a verification condition for every
+  {term}`parametric rule` and sanity checks triggered by {ref}`--rule_sanity`.
+  See also the {ref}`white-paper`, and the {ref}`user-guide`.
 
 wildcard
 exact

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -101,16 +101,15 @@ model
 example
 counterexample
 witness example
-  We use the terms "model" and "example" interchangeably.
-  In the context of a CVL rule, they refer to an assignment of values to all of
-  the CVL variables and contract storage that either violates an `assert`
-  statement or fulfills a `satisfy` statement.
-  In the `assert` case, we also call the model a "counterexample". In the
-  `satisfy` case, we also call the model "witness example".
-  See {ref}`rule-overview`.
-  In the context of {term}`SMT solver`s, a model is a valuation of the logical
-  constants and uninterpreted functions in the input formula that makes the formula
-  evaluate to `true`, also see {term}`SAT result`.
+  We use the terms “model” and “example” interchangeably. 
+  In the context of a CVL rule, they refer to an assignment of values to all CVL variables and contract storage that either:
+  - violates an `assert` statement, in which case the model is also called a **counterexample**, or
+  - satisfies a `satisfy` statement, in which case it is also called a **witness example**.
+
+  See {ref}`rule-overview` for more on how these are used.
+
+  In the context of SMT solvers, a model refers to a valuation of the logical constants and uninterpreted functions in the input formula that makes the formula evaluate to `true`. 
+  See {term}`SAT result` for more details.
 
 linear arithmetic
 nonlinear arithmetic

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -144,11 +144,11 @@ underapproximation
 optimistic assumptions
 pessimistic assertions
   Some input programs include constructs that the Prover cannot handle precisely and must instead approximate. 
-  This means the Prover may ignore certain behaviors of the program; 
-  for example, what happens when a loop executes more times than a fixed unrolling limit.
+  This means the Prover may ignore certain program behaviors, 
+  such as what happens when a loop executes more times than a fixed unrolling limit.
 
   The Prover provides options that let you choose between 
-  pessimistic and optimistic handling for each such approximation. (See the end of this section for examples.)
+  pessimistic and optimistic handling for each approximation. (See the end of this section for examples.)
 
   In pessimistic mode (the default), the Prover inserts pessimistic assertions 
   that check whether the program includes behavior that requires approximation, 

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -83,7 +83,7 @@ havoc
   2. During rule execution, certain events may cause specific variables to be havoced.
     For example, when calling an external function on an unknown contract, 
     the Prover assumes it could arbitrarily affect the state of a third contract.
-  In both cases, we say that the variable was havoced.
+  
   For more information, see {ref}`havoc-summary` and {ref}`havoc-stmt`.
 
 hyperproperty

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -301,13 +301,13 @@ verification condition
   Usually, a run of the Certora Prover generates many verification conditions.
   For instance, the Prover generates a verification condition for every
   {term}`parametric rule` and sanity checks triggered by {ref}`--rule_sanity`.
-  See also the {ref}`white-paper`, and the {ref}`user-guide`.
+  See also the {ref}`white-paper` and the {ref}`user-guide`.
 
 wildcard
 exact
   A methods block entry that explicitly uses `_` as a receiver is a *wildcard
-  entry*; all other entries are called *exact entries*.  See
-  {doc}`/docs/cvl/methods`.
+  entry*; all other entries are called *exact entries*.
+  See {doc}`/docs/cvl/methods`.
 
 ````
 

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -32,6 +32,8 @@ approximative
 autofinders
 axiomatization
 axiomatized
+bitvector
+bitvectors
 bitwidth
 bitwise
 blockchain


### PR DESCRIPTION
Fixes to the Glossary page, including some rewrites

https://certora-certora-prover-documentation--421.com.readthedocs.build/en/421/docs/user-guide/glossary.html#term-rule-name-pattern