### PR TITLE
Clarify ghosts.md, DOC-406

### DIFF
--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -243,7 +243,6 @@ approximation is {term}`sound`: it won't cause violations to be hidden.  See
 {ref}`grounding` for more detail.
 ```
 
-(ghost-mapping-sums)=
 Ghost Mapping Sums
 ------------------
 

--- a/docs/cvl/expr.md
+++ b/docs/cvl/expr.md
@@ -243,6 +243,7 @@ approximation is {term}`sound`: it won't cause violations to be hidden.  See
 {ref}`grounding` for more detail.
 ```
 
+(ghost-mapping-sums)=
 Ghost Mapping Sums
 ------------------
 

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -114,7 +114,7 @@ function example(address user) {
 }
 ```
 
-You can also use ghost variables in a [`sum` or `usum` expression](project:#ghost-mapping-sums)
+You can also use ghost variables in a [`sum` or `usum` expression](expr.md#ghost-mapping-sums)
 to calculate the total of numeric values in a ghost mapping.
 
 The most common reason to use a ghost is to communicate information from a hook

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -114,7 +114,7 @@ function example(address user) {
 }
 ```
 
-You can also use ghost variables in a [`sum` or `usum` expression](project:ghost-mapping-sums)
+You can also use ghost variables in a [`sum` or `usum` expression](project:#ghost-mapping-sums)
 to calculate the total of numeric values in a ghost mapping.
 
 The most common reason to use a ghost is to communicate information from a hook

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -35,10 +35,12 @@ persistent_ghost ::=  "persistent" "ghost" type id                             (
 type ::= basic_type
        | "mapping" "(" cvl_type "=>" type ")"
 
+axioms ::= axiom [ axioms ]
+
 axiom ::= [ "init_state" ] "axiom" expression ";"
 ```
 
-See {doc}`types` for the `type` and `cvl_type` productions, and {doc}`expr` for
+See {doc}`types` for the `basic_type` and `cvl_type` productions, and {doc}`expr` for
 the `expression` syntax.
 
 (ghost-variables)=
@@ -67,11 +69,13 @@ ghost (uint, uint) x;                              // tuples are not CVL types
 ghost mapping(mapping(uint => uint) => address) y; // mappings cannot be keys
 ```
 
-- [simple `ghost` variable example](https://github.com/Certora/Examples/blob/14668d39a6ddc67af349bc5b82f73db73349ef18/CVLByExample/ERC20/certora/specs/ERC20.spec#L113)
+- [A simple `ghost` variable example](https://github.com/Certora/Examples/blob/f1be39c8ac49e5af9b2d450673dde5c1bc6257f2/DEFI/LiquidityPool/certora/specs/Full.spec#L46)
 
-- This example uses an [`init_state` axiom](https://github.com/Certora/Examples/blob/14668d39a6ddc67af349bc5b82f73db73349ef18/CVLByExample/ERC20/certora/specs/ERC20.spec#L114)
+- [This example](https://github.com/Certora/Examples/blob/f1be39c8ac49e5af9b2d450673dde5c1bc6257f2/DEFI/ERC20/certora/specs/ERC20Fixed.spec#L99) has an `init_state` axiom
 
-- [`ghost mapping` example](https://github.com/Certora/Examples/blob/14668d39a6ddc67af349bc5b82f73db73349ef18/CVLByExample/structs/BankAccounts/certora/specs/Bank.spec#L117)
+- [A `ghost mapping` example](https://github.com/Certora/Examples/blob/f1be39c8ac49e5af9b2d450673dde5c1bc6257f2/CVLByExample/Types/Structs/BankAccounts/certora/specs/structs.spec#L119)
+
+- [A nested `ghost mapping` example](https://github.com/Certora/Examples/blob/f1be39c8ac49e5af9b2d450673dde5c1bc6257f2/CVLByExample/Types/Structs/BankAccounts/certora/specs/structs.spec#L113)
 
 (ghost-functions)=
 Ghost Functions
@@ -109,6 +113,8 @@ function example(address user) {
     balances[user] = x;
 }
 ```
+
+You can also use ghost variables in a [`sum` or `usum` expression](#ghost-mapping-sums) to calculate the total of numeric values in a ghost mapping.
 
 The most common reason to use a ghost is to communicate information from a hook
 back to the rule that triggered it.  For example, the following CVL checks

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -114,7 +114,7 @@ function example(address user) {
 }
 ```
 
-You can also use ghost variables in a [`sum` or `usum` expression](expr.md#ghost-mapping-sums)
+You can also use ghost variables in a [`sum` or `usum` expression](project:ghost-mapping-sums)
 to calculate the total of numeric values in a ghost mapping.
 
 The most common reason to use a ghost is to communicate information from a hook

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -114,7 +114,9 @@ function example(address user) {
 }
 ```
 
-You can also use ghost variables in a [`sum` or `usum` expression](#ghost-mapping-sums) to calculate the total of numeric values in a ghost mapping.
+You can also use ghost variables in a [`sum` or `usum` expression]
+(./expr.md#ghost-mapping-sums) to calculate the total of numeric values in a ghost 
+mapping.
 
 The most common reason to use a ghost is to communicate information from a hook
 back to the rule that triggered it.  For example, the following CVL checks

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -115,7 +115,7 @@ function example(address user) {
 ```
 
 You can also use ghost variables in a [`sum` or `usum` expression]
-(./expr.md#ghost-mapping-sums) to calculate the total of numeric values in a ghost 
+(project:#ghost-mapping-sums) to calculate the total of numeric values in a ghost 
 mapping.
 
 The most common reason to use a ghost is to communicate information from a hook

--- a/docs/cvl/ghosts.md
+++ b/docs/cvl/ghosts.md
@@ -114,9 +114,8 @@ function example(address user) {
 }
 ```
 
-You can also use ghost variables in a [`sum` or `usum` expression]
-(project:#ghost-mapping-sums) to calculate the total of numeric values in a ghost 
-mapping.
+You can also use ghost variables in a [`sum` or `usum` expression](project:#ghost-mapping-sums)
+to calculate the total of numeric values in a ghost mapping.
 
 The most common reason to use a ghost is to communicate information from a hook
 back to the rule that triggered it.  For example, the following CVL checks

--- a/docs/prover/cli/options.md
+++ b/docs/prover/cli/options.md
@@ -2032,17 +2032,19 @@ _Configuration file_
 ]
 ```
 
-```{caution}
+````{caution}
 The `struct_link` syntax does not specify the struct's type name (`TokenPair`, in the example above) because it is applied to all structs. Note the potential for confusion if multiple structs in the same contract use the same name for address fields that should hold different addresses. E.g. if `Bank.sol` also defines 
 
-`struct ReserveTokens {
- IERC20 tokenA;
- IERC20 tokenB;
- IERC20 tokenC;
-}`
+```solidity
+struct ReserveTokens {
+    IERC20 tokenA;
+    IERC20 tokenB;
+    IERC20 tokenC;
+}
+```
 
 ... then the `struct_link` setting above would result in the same fixed address values for `tokenA` and `tokenB` in instances of this struct, which is likely an unintended constraint. Similarly, structs that are values in a mapping or array will _all_ get the same address linkage.
-```
+````
 
 
 Options for job metadata and dashboard filtering

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -82,6 +82,7 @@ enums
 envfree
 executable
 executables
+expr
 expressivity
 foldable
 fuzzer
@@ -113,6 +114,7 @@ iteratively
 lifecycle
 logics
 macOS
+md
 modularity
 modularization
 modularize

--- a/spelling_wordlist.txt
+++ b/spelling_wordlist.txt
@@ -82,7 +82,6 @@ enums
 envfree
 executable
 executables
-expr
 expressivity
 foldable
 fuzzer
@@ -114,7 +113,6 @@ iteratively
 lifecycle
 logics
 macOS
-md
 modularity
 modularization
 modularize


### PR DESCRIPTION

Jira ticket: [DOC-406](https://certora.atlassian.net/browse/DOC-406)

Links to generated documentation:

- [Syntax for ghosts](https://certora-certora-prover-documentation--435.com.readthedocs.build/en/435/docs/cvl/ghosts.html#syntax) - added missing a production for "axioms"
- [Links to ghost declaration examples](https://certora-certora-prover-documentation--435.com.readthedocs.build/en/435/docs/cvl/ghosts.html#declaring-ghost-variables) - added a link to an example of a ghost with nested mappings, and updated the existing example links because they were permalinks to files that have moved in the latest examples repo (potentially confusing).
- [Mention sum / usum with link](https://certora-certora-prover-documentation--435.com.readthedocs.build/en/435/docs/cvl/ghosts.html#using-ghost-variables) 
- For ^^^^^, added the cross-reference target on the [Expressions page](https://certora-certora-prover-documentation--435.com.readthedocs.build/en/435/docs/cvl/expr.html#ghost-mapping-sums) (invisible change).

Also, a fixup of formatting from DOC-294 ([discussion](https://certora.slack.com/archives/C053LR1NB43/p1756257388602939)):  [the code snippet within Caution block for struct_link](https://certora-certora-prover-documentation--435.com.readthedocs.build/en/435/docs/prover/cli/options.html#struct-link)

[DOC-406]: https://certora.atlassian.net/browse/DOC-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ