### PR TITLE
docs(cvl): disambiguating same-name user-defined types by originating contract

### DIFF
--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -163,8 +163,9 @@ rejected.  (Same-named types with *identical* definitions are treated as one typ
 and remain usable.)  To disambiguate, qualify the type by a contract that *imports*
 the definition you want, rather than by the duplicated declaring library: if `Vault`
 imports the first `Math`, then `Vault.Rounding` names that library's `Rounding`, and you can refer to fields using `Vault.Rounding.Floor`.
-Use a contract that imports only the one definition — a contract that imports
-*both* is itself ambiguous.
+Solidity forbids importing two same-named libraries into one file except under
+aliases, so a disambiguating contract normally imports just one of them; a contract
+that (via aliases) imports both is itself ambiguous.
 ```
 
 Additional CVL types

--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -155,14 +155,16 @@ Parent.ChildFileType      invalid3; // ChildFileType is not visible in Parent
 ```
 
 ```{note}
-If two *different* types in the {term}`scene` share the same qualified name — for
-example two vendored libraries both named `Math`, each declaring its own
-`enum Rounding` — then `Math.Rounding` is ambiguous and is rejected.  To
-disambiguate, qualify the type by a contract that *imports* the definition you
-want, rather than by the duplicated declaring library: if `Vault` imports the
-first `Math`, then `Vault.Rounding` names that library's `Rounding`.  This
-requires an importing contract that sees a single definition; a contract that
-imports *both* `Math` libraries is itself ambiguous.
+If two user-defined types in the {term}`scene` share the same qualified name but
+have **different** definitions — for example two vendored libraries both named
+`Math`, one declaring `enum Rounding { Floor, Ceil, Trunc, Expand }` and the other
+`enum Rounding { Down, Up, Zero }` — then `Math.Rounding` is ambiguous and is
+rejected.  (Same-named types with *identical* definitions are treated as one type
+and remain usable.)  To disambiguate, qualify the type by a contract that *imports*
+the definition you want, rather than by the duplicated declaring library: if `Vault`
+imports the first `Math`, then `Vault.Rounding` names that library's `Rounding`.
+Use a contract that imports only the one definition — a contract that imports
+*both* is itself ambiguous.
 ```
 
 Additional CVL types

--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -154,6 +154,17 @@ Child.ParentFileType      invalid2; // user-defined types are not inherited
 Parent.ChildFileType      invalid3; // ChildFileType is not visible in Parent
 ```
 
+```{note}
+If two *different* types in the {term}`scene` share the same qualified name — for
+example two vendored libraries both named `Math`, each declaring its own
+`enum Rounding` — then `Math.Rounding` is ambiguous and is rejected.  To
+disambiguate, qualify the type by a contract that *imports* the definition you
+want, rather than by the duplicated declaring library: if `Vault` imports the
+first `Math`, then `Vault.Rounding` names that library's `Rounding`.  This
+requires an importing contract that sees a single definition; a contract that
+imports *both* `Math` libraries is itself ambiguous.
+```
+
 Additional CVL types
 --------------------
 

--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -156,7 +156,7 @@ Parent.ChildFileType      invalid3; // ChildFileType is not visible in Parent
 
 ```{note}
 If two user-defined types in the {term}`scene` share the same qualified name but
-have **different** definitions — for example two vendored libraries both named
+have **different** definitions — for example two libraries both named
 `Math`, one declaring `enum Rounding { Floor, Ceil, Trunc, Expand }` and the other
 `enum Rounding { Down, Up, Zero }` — then `Math.Rounding` is ambiguous and is
 rejected.  (Same-named types with *identical* definitions are treated as one type

--- a/docs/cvl/types.md
+++ b/docs/cvl/types.md
@@ -162,7 +162,7 @@ have **different** definitions — for example two vendored libraries both named
 rejected.  (Same-named types with *identical* definitions are treated as one type
 and remain usable.)  To disambiguate, qualify the type by a contract that *imports*
 the definition you want, rather than by the duplicated declaring library: if `Vault`
-imports the first `Math`, then `Vault.Rounding` names that library's `Rounding`.
+imports the first `Math`, then `Vault.Rounding` names that library's `Rounding`, and you can refer to fields using `Vault.Rounding.Floor`.
 Use a contract that imports only the one definition — a contract that imports
 *both* is itself ambiguous.
 ```


### PR DESCRIPTION
Adds a short note to the **User-defined types** section of `docs/cvl/types.md`.

Documents the new resolver behavior (EVMVerifier): when two *different* user-defined types in the scene share the same qualified name — e.g. a project vendors two libraries both named `Math`, each with a different `enum Rounding` — that name (`Math.Rounding`) is ambiguous and rejected. To select one, qualify the type by a contract that **imports** the wanted definition (e.g. `Vault.Rounding`) rather than by the duplicated declaring library. The note also states the caveat that the importing contract must see a single definition, and that non-ambiguous names are unaffected.

Brief and slotted right after the existing qualification rules/example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)